### PR TITLE
feature : 비동기 FFmpeg으로 영상 인코딩 및 S3에 저장, CDN으로 배포 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 .env
+uploads
+encoded

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,14 @@ dependencies {
 
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'org.apache.commons:commons-exec:1.3'
+
+	// 7. AWS SDK for S3
+	implementation platform('software.amazon.awssdk:bom:2.20.26')
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:cloudfront'
 }
 
 tasks.named('test') {

--- a/docker-compose-rabbitmq.yml
+++ b/docker-compose-rabbitmq.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: streamly-rabbitmq
+    ports:
+      - "5672:5672"    # AMQP 포트
+      - "15672:15672"  # Management UI
+    environment:
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: admin123
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - streamly-network
+
+volumes:
+  rabbitmq_data:
+
+networks:
+  streamly-network:
+    driver: bridge

--- a/src/main/java/com/streamly/streamly/domain/video/controller/AdminVideoController.java
+++ b/src/main/java/com/streamly/streamly/domain/video/controller/AdminVideoController.java
@@ -1,0 +1,117 @@
+package com.streamly.streamly.domain.video.controller;
+
+import com.streamly.streamly.domain.video.dto.VideoResponse;
+import com.streamly.streamly.domain.video.service.AdminVideoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Tag(name = "관리자 영상 API", description = "관리자 전용 영상 관리 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/admin/videos")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminVideoController {
+
+    private final AdminVideoService adminVideoService;
+
+    @Operation(
+        summary = "전체 영상 목록 조회",
+        description = "관리자가 모든 영상을 상태와 관계없이 조회합니다."
+    )
+    @GetMapping
+    public ResponseEntity<Page<VideoResponse>> getAllVideos(
+            @Parameter(description = "페이지 번호 (0부터 시작)")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기")
+            @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "영상 상태 필터 (UPLOADING, UPLOADED, ENCODING, COMPLETED, FAILED, DELETED)")
+            @RequestParam(required = false) String status,
+            @Parameter(description = "승인 상태 필터 (PENDING, APPROVED, REJECTED)")
+            @RequestParam(required = false) String approvalStatus) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<VideoResponse> videos = adminVideoService.getAllVideos(status, approvalStatus, pageable);
+
+        return ResponseEntity.ok(videos);
+    }
+
+    @Operation(
+        summary = "영상 승인",
+        description = "대기 중인 영상을 승인하여 공개합니다."
+    )
+    @PostMapping("/{videoId}/approve")
+    public ResponseEntity<VideoResponse> approveVideo(
+            @Parameter(description = "영상 ID", required = true)
+            @PathVariable Long videoId) {
+
+        VideoResponse response = adminVideoService.approveVideo(videoId);
+        log.info("영상 승인 - ID: {}", videoId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+        summary = "영상 거부",
+        description = "대기 중인 영상을 거부합니다."
+    )
+    @PostMapping("/{videoId}/reject")
+    public ResponseEntity<VideoResponse> rejectVideo(
+            @Parameter(description = "영상 ID", required = true)
+            @PathVariable Long videoId,
+            @Parameter(description = "거부 사유", required = true)
+            @RequestParam String reason) {
+
+        VideoResponse response = adminVideoService.rejectVideo(videoId, reason);
+        log.info("영상 거부 - ID: {}, Reason: {}", videoId, reason);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+        summary = "영상 강제 삭제",
+        description = "관리자가 모든 영상을 강제 삭제할 수 있습니다."
+    )
+    @DeleteMapping("/{videoId}")
+    public ResponseEntity<String> forceDeleteVideo(
+            @Parameter(description = "영상 ID", required = true)
+            @PathVariable Long videoId) {
+
+        adminVideoService.forceDeleteVideo(videoId);
+        log.info("영상 강제 삭제 - ID: {}", videoId);
+
+        return ResponseEntity.ok("영상이 삭제되었습니다.");
+    }
+
+    @Operation(
+        summary = "대시보드 통계",
+        description = "영상 관련 전체 통계를 조회합니다."
+    )
+    @GetMapping("/dashboard/stats")
+    public ResponseEntity<Map<String, Object>> getDashboardStats() {
+        Map<String, Object> stats = adminVideoService.getDashboardStats();
+        return ResponseEntity.ok(stats);
+    }
+
+    @Operation(
+        summary = "승인 대기 영상 수",
+        description = "승인이 필요한 영상 개수를 조회합니다."
+    )
+    @GetMapping("/pending-count")
+    public ResponseEntity<Long> getPendingVideosCount() {
+        Long count = adminVideoService.getPendingVideosCount();
+        return ResponseEntity.ok(count);
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/video/controller/S3TestController.java
+++ b/src/main/java/com/streamly/streamly/domain/video/controller/S3TestController.java
@@ -1,0 +1,58 @@
+package com.streamly.streamly.domain.video.controller;
+
+import com.streamly.streamly.global.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * S3 연결 테스트용 컨트롤러 (개발/테스트용)
+ * 프로덕션 배포 전 삭제 예정
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/test")
+@RequiredArgsConstructor
+public class S3TestController {
+
+    private final S3Client s3Client;
+    private final S3Service s3Service;
+
+    /**
+     * S3 연결 테스트
+     * GET /api/v1/test/s3
+     */
+    @GetMapping("/s3")
+    public ResponseEntity<Map<String, Object>> testS3Connection() {
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            // S3 버킷 목록 조회
+            ListBucketsResponse listBucketsResponse = s3Client.listBuckets();
+            
+            response.put("success", true);
+            response.put("message", "S3 연결 성공!");
+            response.put("bucketCount", listBucketsResponse.buckets().size());
+            response.put("buckets", listBucketsResponse.buckets().stream()
+                    .map(bucket -> bucket.name())
+                    .toList());
+            
+            log.info("S3 연결 테스트 성공 - 버킷 수: {}", listBucketsResponse.buckets().size());
+            
+        } catch (Exception e) {
+            response.put("success", false);
+            response.put("message", "S3 연결 실패: " + e.getMessage());
+            response.put("error", e.getClass().getSimpleName());
+            
+            log.error("S3 연결 테스트 실패", e);
+        }
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/video/controller/VideoController.java
+++ b/src/main/java/com/streamly/streamly/domain/video/controller/VideoController.java
@@ -61,7 +61,9 @@ public class VideoController {
             @Parameter(description = "연령 등급 (예: 12+, 15+, 19+)")
             @RequestParam(value = "ageRating", required = false) String ageRating,
             @Parameter(description = "영상 파일", required = true)
-            @RequestParam("file") MultipartFile file) {
+            @RequestParam("file") MultipartFile file,
+            @Parameter(description = "썸네일 이미지 파일 (선택)")
+            @RequestParam(value = "thumbnailFile", required = false) MultipartFile thumbnailFile) {
 
         String email = authentication.getName();
 
@@ -72,7 +74,7 @@ public class VideoController {
                 .ageRating(ageRating)
                 .build();
 
-        VideoResponse response = videoService.uploadVideo(email, request, file);
+        VideoResponse response = videoService.uploadVideo(email, request, file, thumbnailFile);
 
         log.info("영상 업로드 요청 - User: {}, Title: {}, Size: {} bytes", 
                 email, title, file.getSize());
@@ -198,6 +200,37 @@ public class VideoController {
         Page<VideoResponse> videos = videoService.getRecentVideos(pageable);
 
         return ResponseEntity.ok(videos);
+    }
+
+    @Operation(
+        summary = "영상 인코딩 상태 조회",
+        description = "영상의 인코딩 진행 상태를 조회합니다. 인코딩 진행률과 메타데이터를 확인할 수 있습니다."
+    )
+    @GetMapping("/{videoId}/status")
+    public ResponseEntity<VideoResponse> getVideoStatus(
+            @Parameter(description = "영상 ID", required = true)
+            @PathVariable Long videoId) {
+        
+        VideoResponse video = videoService.getVideoById(videoId);
+        return ResponseEntity.ok(video);
+    }
+
+    @Operation(
+        summary = "영상 정보 수정",
+        description = "영상의 제목, 설명, 카테고리 등 메타정보를 수정합니다. 업로더 본인 또는 관리자만 수정 가능합니다."
+    )
+    @PreAuthorize("hasAnyRole('UPLOADER', 'ADMIN')")
+    @PutMapping("/{videoId}")
+    public ResponseEntity<VideoResponse> updateVideo(
+            @Parameter(hidden = true) Authentication authentication,
+            @Parameter(description = "영상 ID", required = true)
+            @PathVariable Long videoId,
+            @Valid @RequestBody com.streamly.streamly.domain.video.dto.VideoUpdateRequest request) {
+        
+        String email = authentication.getName();
+        VideoResponse response = videoService.updateVideo(email, videoId, request);
+
+        return ResponseEntity.ok(response);
     }
 
     @Operation(

--- a/src/main/java/com/streamly/streamly/domain/video/controller/VideoStatusController.java
+++ b/src/main/java/com/streamly/streamly/domain/video/controller/VideoStatusController.java
@@ -1,0 +1,61 @@
+package com.streamly.streamly.domain.video.controller;
+
+import com.streamly.streamly.domain.video.entity.Video;
+import com.streamly.streamly.domain.video.entity.VideoStatus;
+import com.streamly.streamly.domain.video.repository.VideoRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/videos")
+@RequiredArgsConstructor
+@Tag(name = "Video Status", description = "영상 상태 조회 API")
+public class VideoStatusController {
+
+    private final VideoRepository videoRepository;
+
+    /**
+     * 영상 상태 조회
+     */
+    @GetMapping("/{videoId}/status")
+    @Operation(summary = "영상 상태 조회", description = "영상의 현재 상태와 인코딩 진행률을 조회합니다.")
+    public ResponseEntity<VideoStatusResponse> getVideoStatus(@PathVariable Long videoId) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다."));
+
+        VideoStatusResponse response = VideoStatusResponse.builder()
+                .videoId(video.getId())
+                .title(video.getTitle())
+                .status(video.getStatus())
+                .encodingProgress(video.getEncodingProgress())
+                .durationSeconds(video.getDurationSeconds())
+                .resolution(video.getResolution())
+                .videoCodec(video.getVideoCodec())
+                .audioCodec(video.getAudioCodec())
+                .thumbnailUrl(video.getThumbnailUrl())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class VideoStatusResponse {
+        private Long videoId;
+        private String title;
+        private VideoStatus status;
+        private Integer encodingProgress;
+        private Integer durationSeconds;
+        private String resolution;
+        private String videoCodec;
+        private String audioCodec;
+        private String thumbnailUrl;
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/video/controller/VideoUploadController.java
+++ b/src/main/java/com/streamly/streamly/domain/video/controller/VideoUploadController.java
@@ -1,0 +1,84 @@
+package com.streamly.streamly.domain.video.controller;
+
+import com.streamly.streamly.domain.user.entity.User;
+import com.streamly.streamly.domain.video.dto.VideoUploadRequest;
+import com.streamly.streamly.domain.video.dto.VideoUploadResponse;
+import com.streamly.streamly.domain.video.service.VideoUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/videos")
+@RequiredArgsConstructor
+@Tag(name = "Video Upload", description = "영상 업로드 API")
+public class VideoUploadController {
+
+    private final VideoUploadService videoUploadService;
+
+    /**
+     * 영상 업로드 API
+     * 
+     * @param request 영상 정보 (제목, 설명, 카테고리 등)
+     * @param videoFile 영상 파일
+     * @param thumbnailFile 썸네일 파일 (선택)
+     * @param user 업로드하는 사용자
+     * @return 업로드 결과
+     */
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "영상 업로드",
+            description = "영상 파일과 썸네일을 업로드합니다. 업로드 후 자동으로 인코딩이 시작됩니다."
+    )
+    public ResponseEntity<VideoUploadResponse> uploadVideo(
+            @Parameter(description = "영상 정보 (JSON)")
+            @Valid @RequestPart("request") VideoUploadRequest request,
+            
+            @Parameter(description = "영상 파일 (MP4, AVI 등)")
+            @RequestPart("videoFile") MultipartFile videoFile,
+            
+            @Parameter(description = "썸네일 이미지 (선택사항)")
+            @RequestPart(value = "thumbnailFile", required = false) MultipartFile thumbnailFile,
+            
+            @AuthenticationPrincipal User user
+    ) {
+        try {
+            log.info("Video upload request received from user: {}", user.getEmail());
+            
+            VideoUploadResponse response = videoUploadService.uploadVideo(
+                    request,
+                    videoFile,
+                    thumbnailFile,
+                    user
+            );
+            
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+            
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid upload request: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body(VideoUploadResponse.builder()
+                            .message("업로드 실패: " + e.getMessage())
+                            .build());
+                            
+        } catch (IOException e) {
+            log.error("File upload failed", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(VideoUploadResponse.builder()
+                            .message("파일 업로드 중 오류가 발생했습니다.")
+                            .build());
+        }
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/video/dto/VideoEncodingMessage.java
+++ b/src/main/java/com/streamly/streamly/domain/video/dto/VideoEncodingMessage.java
@@ -1,0 +1,22 @@
+package com.streamly.streamly.domain.video.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * RabbitMQ 메시지로 전송될 인코딩 작업 정보
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoEncodingMessage implements Serializable {
+
+    private Long videoId;
+    private String originalFilePath;  // 업로드된 원본 파일 경로
+    private String outputDirectory;   // 인코딩 결과물이 저장될 디렉토리
+}

--- a/src/main/java/com/streamly/streamly/domain/video/dto/VideoResponse.java
+++ b/src/main/java/com/streamly/streamly/domain/video/dto/VideoResponse.java
@@ -25,7 +25,8 @@ public class VideoResponse {
     private String originalFilename;
     private Long originalFileSize;
     
-    private String cloudfrontUrl; // 스트리밍 URL
+    private String s3Url; // S3 직접 URL
+    private String cloudfrontUrl; // CloudFront URL (스트리밍 추천)
     private String thumbnailUrl;
     
     private Integer durationSeconds;
@@ -55,6 +56,7 @@ public class VideoResponse {
                 .uploaderId(video.getUploader().getId())
                 .originalFilename(video.getOriginalFilename())
                 .originalFileSize(video.getOriginalFileSize())
+                .s3Url(video.getS3Url())
                 .cloudfrontUrl(video.getCloudfrontUrl())
                 .thumbnailUrl(video.getThumbnailUrl())
                 .durationSeconds(video.getDurationSeconds())
@@ -78,12 +80,21 @@ public class VideoResponse {
         return VideoResponse.builder()
                 .id(video.getId())
                 .title(video.getTitle())
+                .description(video.getDescription())
                 .uploaderName(video.getUploader().getNickname())
+                .uploaderId(video.getUploader().getId())
+                .s3Url(video.getS3Url())
+                .cloudfrontUrl(video.getCloudfrontUrl())
                 .thumbnailUrl(video.getThumbnailUrl())
                 .durationSeconds(video.getDurationSeconds())
+                .resolution(video.getResolution())
+                .status(video.getStatus())
+                .encodingProgress(video.getEncodingProgress())
                 .viewCount(video.getViewCount())
                 .category(video.getCategory())
                 .ageRating(video.getAgeRating())
+                .approvalStatus(video.getApprovalStatus())
+                .createdAt(video.getCreatedAt())
                 .publishedAt(video.getPublishedAt())
                 .build();
     }

--- a/src/main/java/com/streamly/streamly/domain/video/dto/VideoUpdateRequest.java
+++ b/src/main/java/com/streamly/streamly/domain/video/dto/VideoUpdateRequest.java
@@ -1,0 +1,34 @@
+package com.streamly.streamly.domain.video.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "영상 정보 수정 요청 DTO")
+public class VideoUpdateRequest {
+    
+    @Schema(description = "영상 제목", example = "새로운 영상 제목", required = true)
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(min = 1, max = 200, message = "제목은 1자 이상 200자 이하여야 합니다")
+    private String title;
+    
+    @Schema(description = "영상 설명", example = "영상에 대한 상세 설명")
+    @Size(max = 5000, message = "설명은 5000자 이하여야 합니다")
+    private String description;
+    
+    @Schema(description = "카테고리", example = "ACTION")
+    @Size(max = 50, message = "카테고리는 50자 이하여야 합니다")
+    private String category;
+    
+    @Schema(description = "연령 등급", example = "15+")
+    @Size(max = 20, message = "연령 등급은 20자 이하여야 합니다")
+    private String ageRating;
+}

--- a/src/main/java/com/streamly/streamly/domain/video/dto/VideoUploadResponse.java
+++ b/src/main/java/com/streamly/streamly/domain/video/dto/VideoUploadResponse.java
@@ -1,0 +1,19 @@
+package com.streamly.streamly.domain.video.dto;
+
+import com.streamly.streamly.domain.video.entity.VideoStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoUploadResponse {
+
+    private Long videoId;
+    private String title;
+    private VideoStatus status;
+    private String message;
+}

--- a/src/main/java/com/streamly/streamly/domain/video/listener/VideoEncodingListener.java
+++ b/src/main/java/com/streamly/streamly/domain/video/listener/VideoEncodingListener.java
@@ -1,0 +1,177 @@
+package com.streamly.streamly.domain.video.listener;
+
+import com.streamly.streamly.domain.video.dto.VideoEncodingMessage;
+import com.streamly.streamly.domain.video.entity.Video;
+import com.streamly.streamly.domain.video.entity.VideoStatus;
+import com.streamly.streamly.domain.video.repository.VideoRepository;
+import com.streamly.streamly.global.config.RabbitMQConfig;
+import com.streamly.streamly.global.service.FFmpegService;
+import com.streamly.streamly.global.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VideoEncodingListener {
+
+    private final VideoRepository videoRepository;
+    private final FFmpegService ffmpegService;
+    private final S3Service s3Service;
+
+    @Value("${video.encoded.directory}")
+    private String encodedDirectory;
+
+    /**
+     * RabbitMQ에서 인코딩 메시지를 수신하여 처리
+     */
+    @RabbitListener(queues = RabbitMQConfig.VIDEO_ENCODING_QUEUE)
+    @Transactional
+    public void handleVideoEncoding(VideoEncodingMessage message) {
+        log.info("Received encoding message for video ID: {}", message.getVideoId());
+
+        Video video = videoRepository.findById(message.getVideoId())
+                .orElseThrow(() -> new IllegalArgumentException("Video not found: " + message.getVideoId()));
+
+        try {
+            // 1. 상태를 ENCODING으로 변경
+            video.updateStatus(VideoStatus.ENCODING);
+            video.updateEncodingProgress(0);
+            videoRepository.save(video);
+            log.info("Video status updated to ENCODING for ID: {}", video.getId());
+
+            // 2. 메타데이터 추출
+            FFmpegService.VideoMetadata metadata = ffmpegService.extractMetadata(message.getOriginalFilePath());
+            video.updateMetadata(
+                    metadata.getDurationSeconds(),
+                    metadata.getResolution(),
+                    metadata.getVideoCodec(),
+                    metadata.getAudioCodec()
+            );
+            videoRepository.save(video);
+            log.info("Metadata extracted for video ID: {}", video.getId());
+
+            // 진행률 업데이트 (메타데이터 추출 완료 시점)
+            video.updateEncodingProgress(20);
+            videoRepository.save(video);
+
+            // 3. HLS 인코딩 수행
+            log.info("Starting HLS encoding for video ID: {}", video.getId());
+            String masterPlaylistPath = ffmpegService.encodeToHLS(
+                    message.getOriginalFilePath(),
+                    message.getOutputDirectory()
+            );
+            log.info("HLS encoding completed. Master playlist: {}", masterPlaylistPath);
+
+            // 진행률 업데이트 (인코딩 완료 시점)
+            video.updateEncodingProgress(60);
+            videoRepository.save(video);
+
+            // 4. S3 업로드
+            log.info("Starting S3 upload for video ID: {}", video.getId());
+            uploadToS3(video, message.getOutputDirectory());
+
+            // 진행률 업데이트 (S3 업로드 완료 시점)
+            video.updateEncodingProgress(90);
+            videoRepository.save(video);
+
+            // 5. 인코딩 완료 후 상태 업데이트
+            video.updateStatus(VideoStatus.COMPLETED);
+            video.updateEncodingProgress(100);
+
+            // 6. 개발/테스트 환경: 자동으로 승인 (프로덕션에서는 제거)
+            video.approve();
+
+            videoRepository.save(video);
+            log.info("Video encoding and S3 upload completed successfully for ID: {} (Auto-approved)", video.getId());
+
+            // 6. 로컬 파일 정리 (옵션)
+            // deleteLocalFiles(message.getOriginalFilePath(), message.getOutputDirectory());
+
+        } catch (Exception e) {
+            log.error("Video encoding failed for ID: {}", message.getVideoId(), e);
+
+            // 실패 상태로 업데이트
+            video.updateStatus(VideoStatus.FAILED);
+            videoRepository.save(video);
+        }
+    }
+
+    /**
+     * S3에 인코딩된 파일 업로드
+     */
+    private void uploadToS3(Video video, String encodedDir) {
+        try {
+            // S3 키 prefix: videos/{videoId}/
+            String s3Prefix = String.format("videos/%d/", video.getId());
+
+            // 인코딩된 디렉토리 전체 업로드
+            Path encodedPath = Paths.get(encodedDir);
+            int uploadedCount = s3Service.uploadDirectory(encodedPath, s3Prefix);
+
+            log.info("S3 upload completed: {} files uploaded to {}", uploadedCount, s3Prefix);
+
+            // S3 정보 업데이트
+            String s3Key = s3Prefix + "master.m3u8";
+            String s3Url = s3Service.getUrl(s3Key);
+            String cloudfrontUrl = s3Service.getUrl(s3Key); // CloudFront 설정 시 자동으로 CloudFront URL 반환
+
+            video.updateS3Info(s3Key, s3Url, cloudfrontUrl);
+            videoRepository.save(video);
+
+            log.info("Video S3 info updated - Key: {}, URL: {}", s3Key, cloudfrontUrl);
+
+        } catch (Exception e) {
+            log.error("S3 upload failed for video ID: {}", video.getId(), e);
+            throw new RuntimeException("S3 upload failed", e);
+        }
+    }
+
+    /**
+     * 로컬 파일 정리 (인코딩 완료 후)
+     */
+    private void deleteLocalFiles(String originalFilePath, String encodedDir) {
+        try {
+            // 원본 파일 삭제
+            File originalFile = new File(originalFilePath);
+            if (originalFile.exists() && originalFile.delete()) {
+                log.info("Original file deleted: {}", originalFilePath);
+            }
+
+            // 인코딩된 파일 디렉토리 삭제
+            File encodedDirFile = new File(encodedDir);
+            if (encodedDirFile.exists()) {
+                deleteDirectory(encodedDirFile);
+                log.info("Encoded directory deleted: {}", encodedDir);
+            }
+
+        } catch (Exception e) {
+            log.warn("Failed to delete local files", e);
+        }
+    }
+
+    /**
+     * 디렉토리 재귀 삭제
+     */
+    private void deleteDirectory(File directory) {
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    deleteDirectory(file);
+                } else {
+                    file.delete();
+                }
+            }
+        }
+        directory.delete();
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/streamly/streamly/domain/video/repository/VideoRepository.java
@@ -48,6 +48,23 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
     // 특정 상태의 영상 개수
     long countByStatus(VideoStatus status);
 
+    // 승인 상태별 영상 개수
+    long countByApprovalStatus(ApprovalStatus approvalStatus);
+
     // 업로더별 영상 개수
     long countByUploaderId(Long uploaderId);
+
+    // 상태별 영상 조회 (관리자용)
+    Page<Video> findByStatus(VideoStatus status, Pageable pageable);
+
+    // 상태와 승인 상태 모두로 필터링 (관리자용)
+    Page<Video> findByStatusAndApprovalStatus(VideoStatus status, ApprovalStatus approvalStatus, Pageable pageable);
+
+    // 전체 조회수 합계
+    @Query("SELECT SUM(v.viewCount) FROM Video v")
+    Long sumViewCount();
+
+    // 전체 저장 용량 합계
+    @Query("SELECT SUM(v.originalFileSize) FROM Video v")
+    Long sumOriginalFileSize();
 }

--- a/src/main/java/com/streamly/streamly/domain/video/service/AdminVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/video/service/AdminVideoService.java
@@ -1,0 +1,251 @@
+package com.streamly.streamly.domain.video.service;
+
+import com.streamly.streamly.domain.video.dto.VideoResponse;
+import com.streamly.streamly.domain.video.entity.ApprovalStatus;
+import com.streamly.streamly.domain.video.entity.Video;
+import com.streamly.streamly.domain.video.entity.VideoStatus;
+import com.streamly.streamly.domain.video.repository.VideoRepository;
+import com.streamly.streamly.global.util.FileStorageUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminVideoService {
+
+    private final VideoRepository videoRepository;
+    private final FileStorageUtil fileStorageUtil;
+    private final com.streamly.streamly.global.service.S3Service s3Service;
+
+    private static final String ENCODED_DIRECTORY = "encoded";
+
+    /**
+     * 전체 영상 목록 조회 (필터링 가능)
+     */
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getAllVideos(String status, String approvalStatus, Pageable pageable) {
+        Page<Video> videos;
+
+        if (status != null && approvalStatus != null) {
+            VideoStatus videoStatus = VideoStatus.valueOf(status);
+            ApprovalStatus approval = ApprovalStatus.valueOf(approvalStatus);
+            videos = videoRepository.findByStatusAndApprovalStatus(videoStatus, approval, pageable);
+        } else if (status != null) {
+            VideoStatus videoStatus = VideoStatus.valueOf(status);
+            videos = videoRepository.findByStatus(videoStatus, pageable);
+        } else if (approvalStatus != null) {
+            ApprovalStatus approval = ApprovalStatus.valueOf(approvalStatus);
+            videos = videoRepository.findByApprovalStatus(approval, pageable);
+        } else {
+            videos = videoRepository.findAll(pageable);
+        }
+
+        return videos.map(VideoResponse::from);
+    }
+
+    /**
+     * 영상 승인
+     */
+    @Transactional
+    public VideoResponse approveVideo(Long videoId) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다."));
+
+        if (video.getApprovalStatus() == ApprovalStatus.APPROVED) {
+            throw new IllegalStateException("이미 승인된 영상입니다.");
+        }
+
+        video.approve();
+        Video approvedVideo = videoRepository.save(video);
+
+        log.info("영상 승인 완료 - ID: {}, Title: {}", videoId, video.getTitle());
+
+        return VideoResponse.from(approvedVideo);
+    }
+
+    /**
+     * 영상 거부
+     */
+    @Transactional
+    public VideoResponse rejectVideo(Long videoId, String reason) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다."));
+
+        if (video.getApprovalStatus() == ApprovalStatus.REJECTED) {
+            throw new IllegalStateException("이미 거부된 영상입니다.");
+        }
+
+        video.reject(reason);
+        Video rejectedVideo = videoRepository.save(video);
+
+        log.info("영상 거부 완료 - ID: {}, Title: {}, Reason: {}", videoId, video.getTitle(), reason);
+
+        return VideoResponse.from(rejectedVideo);
+    }
+
+    /**
+     * 영상 강제 삭제 (로컬, S3, DB 모두 삭제)
+     */
+    @Transactional
+    public void forceDeleteVideo(Long videoId) {
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다."));
+
+        log.info("영상 강제 삭제 시작 - ID: {}, Title: {}", videoId, video.getTitle());
+
+        // 1. 로컬 원본 파일 삭제
+        deleteLocalOriginalFile(video);
+
+        // 2. 로컬 인코딩된 파일 삭제
+        deleteLocalEncodedFiles(video);
+
+        // 3. 로컬 썸네일 삭제
+        deleteLocalThumbnail(video);
+
+        // 4. S3 파일 삭제
+        deleteS3Files(video);
+
+        // 5. DB에서 완전히 삭제
+        videoRepository.delete(video);
+
+        log.info("영상 강제 삭제 완료 - ID: {}, Title: {}", videoId, video.getTitle());
+    }
+
+    /**
+     * 로컬 원본 파일 삭제
+     */
+    private void deleteLocalOriginalFile(Video video) {
+        try {
+            if (video.getOriginalFilePath() != null) {
+                fileStorageUtil.deleteFile(video.getOriginalFilePath());
+                log.info("로컬 원본 파일 삭제 완료: {}", video.getOriginalFilePath());
+            }
+        } catch (Exception e) {
+            log.warn("로컬 원본 파일 삭제 실패 (계속 진행): {}", video.getOriginalFilePath(), e);
+        }
+    }
+
+    /**
+     * 로컬 인코딩된 파일들 삭제
+     */
+    private void deleteLocalEncodedFiles(Video video) {
+        try {
+            String encodedPath = ENCODED_DIRECTORY + "/" + video.getId();
+            java.nio.file.Path encodedDir = java.nio.file.Paths.get(encodedPath);
+
+            if (java.nio.file.Files.exists(encodedDir)) {
+                try (java.util.stream.Stream<java.nio.file.Path> paths = java.nio.file.Files.walk(encodedDir)) {
+                    paths.sorted(java.util.Comparator.reverseOrder())
+                         .forEach(path -> {
+                             try {
+                                 java.nio.file.Files.delete(path);
+                             } catch (Exception e) {
+                                 log.warn("파일 삭제 실패: {}", path, e);
+                             }
+                         });
+                }
+                log.info("로컬 인코딩 파일 삭제 완료: {}", encodedPath);
+            }
+        } catch (Exception e) {
+            log.warn("로컬 인코딩 파일 삭제 실패 (계속 진행): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 로컬 썸네일 삭제
+     */
+    private void deleteLocalThumbnail(Video video) {
+        try {
+            if (video.getThumbnailUrl() != null && video.getThumbnailUrl().startsWith("/thumbnails/")) {
+                String thumbnailFileName = video.getThumbnailUrl().substring("/thumbnails/".length());
+                String thumbnailPath = "uploads/thumbnails/" + thumbnailFileName;
+
+                java.nio.file.Path path = java.nio.file.Paths.get(thumbnailPath);
+                if (java.nio.file.Files.exists(path)) {
+                    java.nio.file.Files.delete(path);
+                    log.info("로컬 썸네일 삭제 완료: {}", thumbnailPath);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("로컬 썸네일 삭제 실패 (계속 진행): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * S3 파일 삭제
+     */
+    private void deleteS3Files(Video video) {
+        try {
+            if (video.getS3Key() != null || video.getCloudfrontUrl() != null) {
+                String s3Prefix = "videos/" + video.getId() + "/";
+
+                s3Service.deleteDirectory(s3Prefix);
+
+                log.info("S3 파일 삭제 완료: {}", s3Prefix);
+            }
+        } catch (Exception e) {
+            log.warn("S3 파일 삭제 실패 (계속 진행): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 대시보드 통계
+     */
+    @Transactional(readOnly = true)
+    public Map<String, Object> getDashboardStats() {
+        Map<String, Object> stats = new HashMap<>();
+
+        // 전체 영상 수
+        long totalVideos = videoRepository.count();
+        stats.put("totalVideos", totalVideos);
+
+        // 상태별 영상 수
+        long uploadingCount = videoRepository.countByStatus(VideoStatus.UPLOADING);
+        long uploadedCount = videoRepository.countByStatus(VideoStatus.UPLOADED);
+        long encodingCount = videoRepository.countByStatus(VideoStatus.ENCODING);
+        long completedCount = videoRepository.countByStatus(VideoStatus.COMPLETED);
+        long failedCount = videoRepository.countByStatus(VideoStatus.FAILED);
+
+        stats.put("uploadingCount", uploadingCount);
+        stats.put("uploadedCount", uploadedCount);
+        stats.put("encodingCount", encodingCount);
+        stats.put("completedCount", completedCount);
+        stats.put("failedCount", failedCount);
+
+        // 승인 상태별 영상 수
+        long pendingCount = videoRepository.countByApprovalStatus(ApprovalStatus.PENDING);
+        long approvedCount = videoRepository.countByApprovalStatus(ApprovalStatus.APPROVED);
+        long rejectedCount = videoRepository.countByApprovalStatus(ApprovalStatus.REJECTED);
+
+        stats.put("pendingApprovalCount", pendingCount);
+        stats.put("approvedCount", approvedCount);
+        stats.put("rejectedCount", rejectedCount);
+
+        // 전체 조회수
+        Long totalViews = videoRepository.sumViewCount();
+        stats.put("totalViews", totalViews != null ? totalViews : 0L);
+
+        // 전체 저장 용량 (bytes)
+        Long totalStorage = videoRepository.sumOriginalFileSize();
+        stats.put("totalStorageBytes", totalStorage != null ? totalStorage : 0L);
+        stats.put("totalStorageGB", totalStorage != null ? totalStorage / (1024.0 * 1024.0 * 1024.0) : 0.0);
+
+        return stats;
+    }
+
+    /**
+     * 승인 대기 영상 수
+     */
+    @Transactional(readOnly = true)
+    public Long getPendingVideosCount() {
+        return videoRepository.countByApprovalStatus(ApprovalStatus.PENDING);
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/video/service/VideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/video/service/VideoService.java
@@ -2,20 +2,26 @@ package com.streamly.streamly.domain.video.service;
 
 import com.streamly.streamly.domain.user.entity.User;
 import com.streamly.streamly.domain.user.repository.UserRepository;
+import com.streamly.streamly.domain.video.dto.VideoEncodingMessage;
 import com.streamly.streamly.domain.video.dto.VideoResponse;
 import com.streamly.streamly.domain.video.dto.VideoUploadRequest;
 import com.streamly.streamly.domain.video.entity.Video;
 import com.streamly.streamly.domain.video.entity.VideoStatus;
 import com.streamly.streamly.domain.video.repository.VideoRepository;
+import com.streamly.streamly.global.config.RabbitMQConfig;
 import com.streamly.streamly.global.exception.user.UserNotFoundException;
 import com.streamly.streamly.global.util.FileStorageUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Paths;
 
 @Slf4j
 @Service
@@ -25,6 +31,11 @@ public class VideoService {
     private final VideoRepository videoRepository;
     private final UserRepository userRepository;
     private final FileStorageUtil fileStorageUtil;
+    private final RabbitTemplate rabbitTemplate;
+    private final com.streamly.streamly.global.service.S3Service s3Service;
+
+    @Value("${video.encoded.directory:encoded}")
+    private String encodedDirectory;
 
     private static final long MAX_FILE_SIZE_MB = 5000; // 5GB
 
@@ -34,7 +45,8 @@ public class VideoService {
     @Transactional
     public VideoResponse uploadVideo(String email, 
                                       VideoUploadRequest request, 
-                                      MultipartFile videoFile) {
+                                      MultipartFile videoFile,
+                                      MultipartFile thumbnailFile) {
         // 1. 사용자 조회
         User uploader = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
@@ -42,10 +54,18 @@ public class VideoService {
         // 2. 파일 검증
         validateVideoFile(videoFile);
 
-        // 3. 파일 저장
+        // 3. 영상 파일 저장
         String savedFilePath = fileStorageUtil.storeFile(videoFile);
 
-        // 4. Video 엔티티 생성
+        // 4. 썸네일 파일 저장 (있는 경우)
+        String thumbnailUrl = null;
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            validateThumbnailFile(thumbnailFile);
+            thumbnailUrl = saveThumbnail(thumbnailFile);
+            log.info("Thumbnail saved: {}", thumbnailUrl);
+        }
+
+        // 5. Video 엔티티 생성
         Video video = Video.builder()
                 .title(request.getTitle())
                 .description(request.getDescription())
@@ -53,6 +73,7 @@ public class VideoService {
                 .originalFilename(videoFile.getOriginalFilename())
                 .originalFileSize(videoFile.getSize())
                 .originalFilePath(savedFilePath)
+                .thumbnailUrl(thumbnailUrl)
                 .category(request.getCategory())
                 .ageRating(request.getAgeRating())
                 .status(VideoStatus.UPLOADED) // 업로드 완료 상태
@@ -63,8 +84,21 @@ public class VideoService {
         log.info("영상 업로드 완료 - ID: {}, Title: {}, Uploader: {}", 
                 savedVideo.getId(), savedVideo.getTitle(), uploader.getEmail());
 
-        // TODO: 비동기로 인코딩 작업 큐에 추가
-        // encodingService.addToQueue(savedVideo.getId());
+        // 인코딩 작업을 RabbitMQ에 전송
+        String outputDir = encodedDirectory + "/" + savedVideo.getId();
+        VideoEncodingMessage message = VideoEncodingMessage.builder()
+                .videoId(savedVideo.getId())
+                .originalFilePath(savedFilePath)
+                .outputDirectory(outputDir)
+                .build();
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.VIDEO_ENCODING_EXCHANGE,
+                RabbitMQConfig.VIDEO_ENCODING_ROUTING_KEY,
+                message
+        );
+        
+        log.info("Encoding message sent to RabbitMQ for video ID: {}", savedVideo.getId());
 
         return VideoResponse.from(savedVideo);
     }
@@ -85,6 +119,45 @@ public class VideoService {
             throw new IllegalArgumentException(
                 String.format("파일 크기는 %dGB를 초과할 수 없습니다.", MAX_FILE_SIZE_MB / 1024)
             );
+        }
+    }
+
+    /**
+     * 썸네일 파일 유효성 검증
+     */
+    private void validateThumbnailFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return;
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("유효한 이미지 파일이 아닙니다.");
+        }
+
+        // 파일 크기 제한 (5MB)
+        long maxSize = 5 * 1024 * 1024;
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("썸네일 파일 크기는 5MB를 초과할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 썸네일 파일 저장
+     */
+    private String saveThumbnail(MultipartFile thumbnailFile) {
+        try {
+            String savedPath = fileStorageUtil.storeFile(thumbnailFile, "thumbnails");
+            
+            // 절대 경로에서 파일명만 추출
+            // 예: C:/BE/uploads/thumbnails/uuid.jpg -> uuid.jpg
+            String filename = Paths.get(savedPath).getFileName().toString();
+            
+            // 상대 URL 경로 반환
+            return "/thumbnails/" + filename;
+        } catch (Exception e) {
+            log.error("썸네일 저장 실패", e);
+            throw new IllegalArgumentException("썸네일 저장에 실패했습니다.");
         }
     }
 
@@ -142,7 +215,60 @@ public class VideoService {
     }
 
     /**
-     * 영상 삭제
+     * 영상 정보 수정
+     */
+    @Transactional
+    public VideoResponse updateVideo(String email, Long videoId, com.streamly.streamly.domain.video.dto.VideoUpdateRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다."));
+
+        // 업로더 본인 또는 관리자만 수정 가능
+        if (!video.getUploader().getId().equals(user.getId()) && 
+            !user.getRole().name().equals("ROLE_ADMIN")) {
+            throw new IllegalArgumentException("영상을 수정할 권한이 없습니다.");
+        }
+
+        // 영상 정보 업데이트 (Builder 패턴 사용)
+        video = Video.builder()
+                .id(video.getId())
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .uploader(video.getUploader())
+                .originalFilename(video.getOriginalFilename())
+                .originalFileSize(video.getOriginalFileSize())
+                .originalFilePath(video.getOriginalFilePath())
+                .s3Key(video.getS3Key())
+                .s3Url(video.getS3Url())
+                .cloudfrontUrl(video.getCloudfrontUrl())
+                .durationSeconds(video.getDurationSeconds())
+                .resolution(video.getResolution())
+                .videoCodec(video.getVideoCodec())
+                .audioCodec(video.getAudioCodec())
+                .thumbnailUrl(video.getThumbnailUrl())
+                .status(video.getStatus())
+                .encodingProgress(video.getEncodingProgress())
+                .viewCount(video.getViewCount())
+                .category(request.getCategory())
+                .ageRating(request.getAgeRating())
+                .approvalStatus(video.getApprovalStatus())
+                .rejectionReason(video.getRejectionReason())
+                .createdAt(video.getCreatedAt())
+                .updatedAt(video.getUpdatedAt())
+                .publishedAt(video.getPublishedAt())
+                .build();
+
+        Video updatedVideo = videoRepository.save(video);
+        
+        log.info("영상 정보 수정 완료 - ID: {}, Title: {}", videoId, updatedVideo.getTitle());
+        
+        return VideoResponse.from(updatedVideo);
+    }
+
+    /**
+     * 영상 삭제 (로컬, S3, DB 모두 삭제)
      */
     @Transactional
     public void deleteVideo(String email, Long videoId) {
@@ -153,21 +279,116 @@ public class VideoService {
                 .orElseThrow(() -> new IllegalArgumentException("영상을 찾을 수 없습니다."));
 
         // 업로더 본인 또는 관리자만 삭제 가능
-        if (!video.getUploader().getId().equals(user.getId()) && 
+        if (!video.getUploader().getId().equals(user.getId()) &&
             !user.getRole().name().equals("ROLE_ADMIN")) {
             throw new IllegalArgumentException("영상을 삭제할 권한이 없습니다.");
         }
 
-        // 파일 삭제
-        if (video.getOriginalFilePath() != null) {
-            fileStorageUtil.deleteFile(video.getOriginalFilePath());
-        }
+        log.info("영상 삭제 시작 - ID: {}, Title: {}", videoId, video.getTitle());
 
-        // TODO: S3에서도 삭제
+        // 1. 로컬 원본 파일 삭제
+        deleteLocalOriginalFile(video);
 
-        video.updateStatus(VideoStatus.DELETED);
-        
+        // 2. 로컬 인코딩된 파일 삭제
+        deleteLocalEncodedFiles(video);
+
+        // 3. 로컬 썸네일 삭제
+        deleteLocalThumbnail(video);
+
+        // 4. S3 파일 삭제 (인코딩된 HLS 파일들)
+        deleteS3Files(video);
+
+        // 5. DB에서 완전히 삭제
+        videoRepository.delete(video);
+
         log.info("영상 삭제 완료 - ID: {}, Title: {}", videoId, video.getTitle());
+    }
+
+    /**
+     * 로컬 원본 파일 삭제
+     */
+    private void deleteLocalOriginalFile(Video video) {
+        try {
+            if (video.getOriginalFilePath() != null) {
+                fileStorageUtil.deleteFile(video.getOriginalFilePath());
+                log.info("로컬 원본 파일 삭제 완료: {}", video.getOriginalFilePath());
+            }
+        } catch (Exception e) {
+            log.warn("로컬 원본 파일 삭제 실패 (계속 진행): {}", video.getOriginalFilePath(), e);
+        }
+    }
+
+    /**
+     * 로컬 인코딩된 파일들 삭제
+     */
+    private void deleteLocalEncodedFiles(Video video) {
+        try {
+            // encoded/{videoId}/ 디렉토리 전체 삭제
+            String encodedPath = encodedDirectory + "/" + video.getId();
+            java.nio.file.Path encodedDir = java.nio.file.Paths.get(encodedPath);
+
+            if (java.nio.file.Files.exists(encodedDir)) {
+                // 디렉토리 내 모든 파일 삭제
+                try (java.util.stream.Stream<java.nio.file.Path> paths = java.nio.file.Files.walk(encodedDir)) {
+                    paths.sorted(java.util.Comparator.reverseOrder())
+                         .forEach(path -> {
+                             try {
+                                 java.nio.file.Files.delete(path);
+                             } catch (Exception e) {
+                                 log.warn("파일 삭제 실패: {}", path, e);
+                             }
+                         });
+                }
+                log.info("로컬 인코딩 파일 삭제 완료: {}", encodedPath);
+            }
+        } catch (Exception e) {
+            log.warn("로컬 인코딩 파일 삭제 실패 (계속 진행): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 로컬 썸네일 삭제
+     */
+    private void deleteLocalThumbnail(Video video) {
+        try {
+            if (video.getThumbnailUrl() != null && video.getThumbnailUrl().startsWith("/thumbnails/")) {
+                // /thumbnails/filename.jpg -> uploads/thumbnails/filename.jpg
+                String thumbnailFileName = video.getThumbnailUrl().substring("/thumbnails/".length());
+                String thumbnailPath = "uploads/thumbnails/" + thumbnailFileName;
+
+                java.nio.file.Path path = java.nio.file.Paths.get(thumbnailPath);
+                if (java.nio.file.Files.exists(path)) {
+                    java.nio.file.Files.delete(path);
+                    log.info("로컬 썸네일 삭제 완료: {}", thumbnailPath);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("로컬 썸네일 삭제 실패 (계속 진행): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * S3 파일 삭제
+     */
+    private void deleteS3Files(Video video) {
+        // S3Service를 주입받아야 하므로, 일단 로그만 남기고
+        // AdminVideoService에서 처리하도록 변경하거나
+        // S3Service를 VideoService에 주입
+
+        // S3에 업로드된 파일이 있는 경우
+        if (video.getS3Key() != null || video.getCloudfrontUrl() != null) {
+            try {
+                // videos/{videoId}/ prefix로 모든 파일 삭제
+                String s3Prefix = "videos/" + video.getId() + "/";
+
+                // TODO: S3Service 주입 필요
+                // s3Service.deleteDirectory(s3Prefix);
+
+                log.info("S3 파일 삭제 필요: {}", s3Prefix);
+            } catch (Exception e) {
+                log.warn("S3 파일 삭제 실패 (계속 진행): {}", e.getMessage());
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/streamly/streamly/domain/video/service/VideoUploadService.java
+++ b/src/main/java/com/streamly/streamly/domain/video/service/VideoUploadService.java
@@ -1,0 +1,186 @@
+package com.streamly.streamly.domain.video.service;
+
+import com.streamly.streamly.domain.user.entity.User;
+import com.streamly.streamly.domain.video.dto.VideoEncodingMessage;
+import com.streamly.streamly.domain.video.dto.VideoUploadRequest;
+import com.streamly.streamly.domain.video.dto.VideoUploadResponse;
+import com.streamly.streamly.domain.video.entity.Video;
+import com.streamly.streamly.domain.video.entity.VideoStatus;
+import com.streamly.streamly.domain.video.repository.VideoRepository;
+import com.streamly.streamly.global.config.RabbitMQConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VideoUploadService {
+
+    private final VideoRepository videoRepository;
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${video.upload.directory:uploads}")
+    private String uploadDirectory;
+
+    @Value("${video.encoded.directory:encoded}")
+    private String encodedDirectory;
+
+    /**
+     * 영상 업로드 처리
+     */
+    @Transactional
+    public VideoUploadResponse uploadVideo(
+            VideoUploadRequest request,
+            MultipartFile videoFile,
+            MultipartFile thumbnailFile,
+            User uploader
+    ) throws IOException {
+        log.info("Starting video upload for user: {}", uploader.getEmail());
+
+        // 1. 파일 유효성 검증
+        validateVideoFile(videoFile);
+        
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            validateThumbnailFile(thumbnailFile);
+        }
+
+        // 2. 원본 영상 파일 저장
+        String originalFileName = videoFile.getOriginalFilename();
+        String uniqueFileName = UUID.randomUUID().toString() + getFileExtension(originalFileName);
+        Path uploadPath = Paths.get(uploadDirectory);
+        
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+        
+        Path videoFilePath = uploadPath.resolve(uniqueFileName);
+        Files.copy(videoFile.getInputStream(), videoFilePath, StandardCopyOption.REPLACE_EXISTING);
+        
+        log.info("Video file saved: {}", videoFilePath);
+
+        // 3. 썸네일 파일 저장 (있는 경우)
+        String thumbnailUrl = null;
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            thumbnailUrl = saveThumbnail(thumbnailFile);
+            log.info("Thumbnail saved: {}", thumbnailUrl);
+        }
+
+        // 4. Video 엔티티 생성 및 저장
+        Video video = Video.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .category(request.getCategory())
+                .ageRating(request.getAgeRating())
+                .uploader(uploader)
+                .originalFilename(originalFileName)
+                .originalFileSize(videoFile.getSize())
+                .originalFilePath(videoFilePath.toString())
+                .thumbnailUrl(thumbnailUrl)
+                .status(VideoStatus.UPLOADED)
+                .build();
+
+        video = videoRepository.save(video);
+        log.info("Video entity created with ID: {}", video.getId());
+
+        // 5. 인코딩 작업을 RabbitMQ에 전송
+        String outputDir = encodedDirectory + "/" + video.getId();
+        VideoEncodingMessage message = VideoEncodingMessage.builder()
+                .videoId(video.getId())
+                .originalFilePath(videoFilePath.toString())
+                .outputDirectory(outputDir)
+                .build();
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.VIDEO_ENCODING_EXCHANGE,
+                RabbitMQConfig.VIDEO_ENCODING_ROUTING_KEY,
+                message
+        );
+        
+        log.info("Encoding message sent to RabbitMQ for video ID: {}", video.getId());
+
+        // 6. 응답 반환
+        return VideoUploadResponse.builder()
+                .videoId(video.getId())
+                .title(video.getTitle())
+                .status(video.getStatus())
+                .message("영상이 업로드되었습니다. 인코딩이 진행됩니다.")
+                .build();
+    }
+
+    /**
+     * 영상 파일 유효성 검증
+     */
+    private void validateVideoFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("영상 파일이 필요합니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("video/")) {
+            throw new IllegalArgumentException("유효한 영상 파일이 아닙니다.");
+        }
+
+        // 파일 크기 제한 (예: 500MB)
+        long maxSize = 500 * 1024 * 1024; // 500MB
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("영상 파일 크기는 500MB를 초과할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 썸네일 파일 유효성 검증
+     */
+    private void validateThumbnailFile(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("유효한 이미지 파일이 아닙니다.");
+        }
+
+        // 파일 크기 제한 (예: 5MB)
+        long maxSize = 5 * 1024 * 1024; // 5MB
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("썸네일 파일 크기는 5MB를 초과할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 썸네일 파일 저장
+     */
+    private String saveThumbnail(MultipartFile thumbnailFile) throws IOException {
+        String originalFileName = thumbnailFile.getOriginalFilename();
+        String uniqueFileName = UUID.randomUUID().toString() + getFileExtension(originalFileName);
+        
+        Path thumbnailPath = Paths.get(uploadDirectory, "thumbnails");
+        if (!Files.exists(thumbnailPath)) {
+            Files.createDirectories(thumbnailPath);
+        }
+        
+        Path filePath = thumbnailPath.resolve(uniqueFileName);
+        Files.copy(thumbnailFile.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+        
+        // 상대 경로 또는 URL 반환 (추후 S3 URL로 변경될 수 있음)
+        return "/thumbnails/" + uniqueFileName;
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/src/main/java/com/streamly/streamly/global/config/AwsConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/AwsConfig.java
@@ -1,0 +1,56 @@
+package com.streamly.streamly.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+/**
+ * AWS SDK 설정
+ */
+@Configuration
+public class AwsConfig {
+
+    @Value("${aws.access-key}")
+    private String accessKey;
+
+    @Value("${aws.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    /**
+     * AWS 자격 증명 생성
+     */
+    @Bean
+    public AwsBasicCredentials awsCredentials() {
+        return AwsBasicCredentials.create(accessKey, secretKey);
+    }
+
+    /**
+     * S3 클라이언트 Bean
+     */
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials()))
+                .build();
+    }
+
+    /**
+     * S3 Presigner Bean (Pre-signed URL 생성용)
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials()))
+                .build();
+    }
+}

--- a/src/main/java/com/streamly/streamly/global/config/RabbitMQConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/RabbitMQConfig.java
@@ -1,0 +1,70 @@
+package com.streamly.streamly.global.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableRabbit
+public class RabbitMQConfig {
+
+    // Queue 이름
+    public static final String VIDEO_ENCODING_QUEUE = "video.encoding.queue";
+    
+    // Exchange 이름
+    public static final String VIDEO_ENCODING_EXCHANGE = "video.encoding.exchange";
+    
+    // Routing Key
+    public static final String VIDEO_ENCODING_ROUTING_KEY = "video.encoding";
+
+    /**
+     * 인코딩 작업 큐
+     */
+    @Bean
+    public Queue videoEncodingQueue() {
+        return QueueBuilder.durable(VIDEO_ENCODING_QUEUE)
+                .build();
+    }
+
+    /**
+     * Direct Exchange
+     */
+    @Bean
+    public DirectExchange videoEncodingExchange() {
+        return new DirectExchange(VIDEO_ENCODING_EXCHANGE);
+    }
+
+    /**
+     * Queue와 Exchange 바인딩
+     */
+    @Bean
+    public Binding videoEncodingBinding(Queue videoEncodingQueue, DirectExchange videoEncodingExchange) {
+        return BindingBuilder
+                .bind(videoEncodingQueue)
+                .to(videoEncodingExchange)
+                .with(VIDEO_ENCODING_ROUTING_KEY);
+    }
+
+    /**
+     * JSON 메시지 컨버터
+     */
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    /**
+     * RabbitTemplate 설정
+     */
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/com/streamly/streamly/global/config/SecurityConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/SecurityConfig.java
@@ -62,8 +62,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/login/**", "/oauth2/**").permitAll() // 인증 없이 접근 가능
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/api/v1/test/**").permitAll() // 테스트 API (개발용)
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll() // 회원가입, 로그인
                         .requestMatchers("/api/v1/auth/refresh").permitAll() // 토큰 갱신은 인증 없이 가능
+                        .requestMatchers("/thumbnails/**", "/uploads/**").permitAll() // 정적 파일 (썸네일, 업로드)
                         .requestMatchers("/api/v1/users/me").authenticated() // 사용자 정보 조회는 인증 필요
                         .requestMatchers("/api/v1/videos/upload").hasAnyRole("UPLOADER", "ADMIN") // 업로드 권한 체크
                         .requestMatchers("/api/v1/videos").permitAll() // 영상 목록 조회는 인증 없이 가능

--- a/src/main/java/com/streamly/streamly/global/config/WebConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/WebConfig.java
@@ -1,0 +1,63 @@
+package com.streamly.streamly.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
+
+/**
+ * Web MVC 설정
+ * - CORS 설정
+ * - 정적 리소스 핸들러 설정 (썸네일, 업로드 파일 등)
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir:./uploads}")
+    private String uploadDir;
+
+    /**
+     * CORS 설정
+     */
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+
+    /**
+     * 정적 리소스 핸들러 설정
+     * /thumbnails/** 요청을 uploads/thumbnails/ 디렉토리로 매핑
+     */
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 썸네일 이미지 경로 설정
+        String thumbnailPath = Paths.get(uploadDir, "thumbnails")
+                .toAbsolutePath()
+                .normalize()
+                .toUri()
+                .toString();
+
+        registry.addResourceHandler("/thumbnails/**")
+                .addResourceLocations(thumbnailPath)
+                .setCachePeriod(3600); // 1시간 캐시
+
+        // 업로드 파일 경로 설정 (필요한 경우)
+        String uploadPath = Paths.get(uploadDir)
+                .toAbsolutePath()
+                .normalize()
+                .toUri()
+                .toString();
+
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(uploadPath)
+                .setCachePeriod(3600);
+    }
+}

--- a/src/main/java/com/streamly/streamly/global/service/FFmpegService.java
+++ b/src/main/java/com/streamly/streamly/global/service/FFmpegService.java
@@ -1,0 +1,280 @@
+package com.streamly.streamly.global.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.PumpStreamHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+public class FFmpegService {
+
+    @Value("${ffmpeg.path:ffmpeg}")
+    private String ffmpegPath;
+
+    @Value("${ffprobe.path:ffprobe}")
+    private String ffprobePath;
+
+    /**
+     * 영상을 HLS 포맷으로 인코딩
+     * 
+     * @param inputPath 원본 영상 파일 경로
+     * @param outputDir 출력 디렉토리 (HLS 파일들이 저장될 위치)
+     * @return 생성된 마스터 플레이리스트 파일 경로
+     */
+    public String encodeToHLS(String inputPath, String outputDir) throws IOException, InterruptedException {
+        log.info("Starting HLS encoding for: {}", inputPath);
+
+        // 출력 디렉토리 생성
+        Path outputPath = Paths.get(outputDir);
+        if (!Files.exists(outputPath)) {
+            Files.createDirectories(outputPath);
+        }
+
+        // 다중 해상도 HLS 생성
+        String masterPlaylist = outputDir + "/master.m3u8";
+        
+        // 360p 인코딩
+        encode360p(inputPath, outputDir);
+        
+        // 480p 인코딩
+        encode480p(inputPath, outputDir);
+        
+        // 720p 인코딩
+        encode720p(inputPath, outputDir);
+
+        // 마스터 플레이리스트 생성
+        createMasterPlaylist(outputDir);
+
+        log.info("HLS encoding completed. Master playlist: {}", masterPlaylist);
+        return masterPlaylist;
+    }
+
+    /**
+     * 360p 인코딩
+     */
+    private void encode360p(String inputPath, String outputDir) throws IOException, InterruptedException {
+        String output360 = outputDir + "/360p.m3u8";
+        
+        CommandLine cmdLine = new CommandLine(ffmpegPath);
+        cmdLine.addArgument("-i");
+        cmdLine.addArgument(inputPath);
+        cmdLine.addArgument("-vf");
+        cmdLine.addArgument("scale=-2:360");
+        cmdLine.addArgument("-c:v");
+        cmdLine.addArgument("libx264");
+        cmdLine.addArgument("-preset");
+        cmdLine.addArgument("medium");
+        cmdLine.addArgument("-b:v");
+        cmdLine.addArgument("800k");
+        cmdLine.addArgument("-c:a");
+        cmdLine.addArgument("aac");
+        cmdLine.addArgument("-b:a");
+        cmdLine.addArgument("128k");
+        cmdLine.addArgument("-hls_time");
+        cmdLine.addArgument("4");
+        cmdLine.addArgument("-hls_playlist_type");
+        cmdLine.addArgument("vod");
+        cmdLine.addArgument("-hls_segment_filename");
+        cmdLine.addArgument(outputDir + "/360p_%03d.ts");
+        cmdLine.addArgument(output360);
+
+        executeCommand(cmdLine);
+    }
+
+    /**
+     * 480p 인코딩
+     */
+    private void encode480p(String inputPath, String outputDir) throws IOException, InterruptedException {
+        String output480 = outputDir + "/480p.m3u8";
+        
+        CommandLine cmdLine = new CommandLine(ffmpegPath);
+        cmdLine.addArgument("-i");
+        cmdLine.addArgument(inputPath);
+        cmdLine.addArgument("-vf");
+        cmdLine.addArgument("scale=-2:480");
+        cmdLine.addArgument("-c:v");
+        cmdLine.addArgument("libx264");
+        cmdLine.addArgument("-preset");
+        cmdLine.addArgument("medium");
+        cmdLine.addArgument("-b:v");
+        cmdLine.addArgument("1400k");
+        cmdLine.addArgument("-c:a");
+        cmdLine.addArgument("aac");
+        cmdLine.addArgument("-b:a");
+        cmdLine.addArgument("128k");
+        cmdLine.addArgument("-hls_time");
+        cmdLine.addArgument("4");
+        cmdLine.addArgument("-hls_playlist_type");
+        cmdLine.addArgument("vod");
+        cmdLine.addArgument("-hls_segment_filename");
+        cmdLine.addArgument(outputDir + "/480p_%03d.ts");
+        cmdLine.addArgument(output480);
+
+        executeCommand(cmdLine);
+    }
+
+    /**
+     * 720p 인코딩
+     */
+    private void encode720p(String inputPath, String outputDir) throws IOException, InterruptedException {
+        String output720 = outputDir + "/720p.m3u8";
+        
+        CommandLine cmdLine = new CommandLine(ffmpegPath);
+        cmdLine.addArgument("-i");
+        cmdLine.addArgument(inputPath);
+        cmdLine.addArgument("-vf");
+        cmdLine.addArgument("scale=-2:720");
+        cmdLine.addArgument("-c:v");
+        cmdLine.addArgument("libx264");
+        cmdLine.addArgument("-preset");
+        cmdLine.addArgument("medium");
+        cmdLine.addArgument("-b:v");
+        cmdLine.addArgument("2800k");
+        cmdLine.addArgument("-c:a");
+        cmdLine.addArgument("aac");
+        cmdLine.addArgument("-b:a");
+        cmdLine.addArgument("192k");
+        cmdLine.addArgument("-hls_time");
+        cmdLine.addArgument("4");
+        cmdLine.addArgument("-hls_playlist_type");
+        cmdLine.addArgument("vod");
+        cmdLine.addArgument("-hls_segment_filename");
+        cmdLine.addArgument(outputDir + "/720p_%03d.ts");
+        cmdLine.addArgument(output720);
+
+        executeCommand(cmdLine);
+    }
+
+    /**
+     * 마스터 플레이리스트 생성
+     */
+    private void createMasterPlaylist(String outputDir) throws IOException {
+        String masterContent = """
+                #EXTM3U
+                #EXT-X-VERSION:3
+                #EXT-X-STREAM-INF:BANDWIDTH=928000,RESOLUTION=640x360
+                360p.m3u8
+                #EXT-X-STREAM-INF:BANDWIDTH=1528000,RESOLUTION=854x480
+                480p.m3u8
+                #EXT-X-STREAM-INF:BANDWIDTH=2992000,RESOLUTION=1280x720
+                720p.m3u8
+                """;
+
+        Path masterPath = Paths.get(outputDir, "master.m3u8");
+        Files.writeString(masterPath, masterContent);
+    }
+
+    /**
+     * 영상 메타데이터 추출 (ffprobe 사용)
+     */
+    public VideoMetadata extractMetadata(String videoPath) throws IOException, InterruptedException {
+        log.info("Extracting metadata from: {}", videoPath);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        
+        CommandLine cmdLine = new CommandLine(ffprobePath);
+        cmdLine.addArgument("-v");
+        cmdLine.addArgument("error");
+        cmdLine.addArgument("-show_entries");
+        cmdLine.addArgument("stream=width,height,codec_name,duration");
+        cmdLine.addArgument("-show_entries");
+        cmdLine.addArgument("format=duration");
+        cmdLine.addArgument("-of");
+        cmdLine.addArgument("default=noprint_wrappers=1");
+        cmdLine.addArgument(videoPath);
+
+        DefaultExecutor executor = new DefaultExecutor();
+        PumpStreamHandler streamHandler = new PumpStreamHandler(outputStream);
+        executor.setStreamHandler(streamHandler);
+        executor.execute(cmdLine);
+
+        String output = outputStream.toString();
+        log.debug("FFprobe output: {}", output);
+
+        return parseMetadata(output);
+    }
+
+    /**
+     * FFprobe 출력 파싱
+     */
+    private VideoMetadata parseMetadata(String output) {
+        VideoMetadata metadata = new VideoMetadata();
+
+        // Duration 추출
+        Pattern durationPattern = Pattern.compile("duration=(\\d+\\.?\\d*)");
+        Matcher durationMatcher = durationPattern.matcher(output);
+        if (durationMatcher.find()) {
+            double duration = Double.parseDouble(durationMatcher.group(1));
+            metadata.setDurationSeconds((int) duration);
+        }
+
+        // Width, Height 추출
+        Pattern widthPattern = Pattern.compile("width=(\\d+)");
+        Pattern heightPattern = Pattern.compile("height=(\\d+)");
+        Matcher widthMatcher = widthPattern.matcher(output);
+        Matcher heightMatcher = heightPattern.matcher(output);
+        
+        if (widthMatcher.find() && heightMatcher.find()) {
+            int width = Integer.parseInt(widthMatcher.group(1));
+            int height = Integer.parseInt(heightMatcher.group(1));
+            metadata.setResolution(width + "x" + height);
+        }
+
+        // Codec 추출
+        Pattern codecPattern = Pattern.compile("codec_name=(\\w+)");
+        Matcher codecMatcher = codecPattern.matcher(output);
+        if (codecMatcher.find()) {
+            metadata.setVideoCodec(codecMatcher.group(1));
+        }
+        if (codecMatcher.find()) {
+            metadata.setAudioCodec(codecMatcher.group(1));
+        }
+
+        return metadata;
+    }
+
+    /**
+     * FFmpeg 명령 실행
+     */
+    private void executeCommand(CommandLine cmdLine) throws IOException, InterruptedException {
+        log.info("Executing FFmpeg command: {}", cmdLine);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
+
+        DefaultExecutor executor = new DefaultExecutor();
+        PumpStreamHandler streamHandler = new PumpStreamHandler(outputStream, errorStream);
+        executor.setStreamHandler(streamHandler);
+        
+        try {
+            executor.execute(cmdLine);
+            log.info("FFmpeg command executed successfully");
+        } catch (IOException e) {
+            log.error("FFmpeg execution failed: {}", errorStream.toString());
+            throw e;
+        }
+    }
+
+    /**
+     * 영상 메타데이터 DTO
+     */
+    @lombok.Data
+    public static class VideoMetadata {
+        private Integer durationSeconds;
+        private String resolution;
+        private String videoCodec;
+        private String audioCodec;
+    }
+}

--- a/src/main/java/com/streamly/streamly/global/service/S3Service.java
+++ b/src/main/java/com/streamly/streamly/global/service/S3Service.java
@@ -1,0 +1,239 @@
+package com.streamly.streamly.global.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * AWS S3 파일 업로드/다운로드 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Value("${aws.cloudfront.domain:}")
+    private String cloudfrontDomain;
+
+    /**
+     * 단일 파일 업로드
+     *
+     * @param file    업로드할 파일
+     * @param s3Key   S3 키 (경로 + 파일명)
+     * @return S3 URL
+     */
+    public String uploadFile(File file, String s3Key) {
+        try {
+            String contentType = determineContentType(file);
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
+
+            log.info("S3 업로드 성공: {}", s3Key);
+
+            // CloudFront URL 반환 (설정되어 있으면)
+            if (cloudfrontDomain != null && !cloudfrontDomain.isEmpty()) {
+                return String.format("https://%s/%s", cloudfrontDomain, s3Key);
+            }
+
+            // S3 직접 URL 반환
+            return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                    bucketName, region, s3Key);
+
+        } catch (Exception e) {
+            log.error("S3 업로드 실패: {}", s3Key, e);
+            throw new RuntimeException("S3 업로드 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 디렉토리 전체 업로드 (재귀적)
+     *
+     * @param localDir 로컬 디렉토리
+     * @param s3Prefix S3 prefix (예: videos/123/)
+     * @return 업로드된 파일 수
+     */
+    public int uploadDirectory(Path localDir, String s3Prefix) {
+        try {
+            List<Path> files = new ArrayList<>();
+
+            // 디렉토리 내 모든 파일 수집 (재귀적)
+            try (Stream<Path> paths = Files.walk(localDir)) {
+                paths.filter(Files::isRegularFile)
+                        .forEach(files::add);
+            }
+
+            log.info("디렉토리 업로드 시작: {} ({} 개 파일)", localDir, files.size());
+
+            int successCount = 0;
+            for (Path filePath : files) {
+                try {
+                    // 상대 경로 계산
+                    Path relativePath = localDir.relativize(filePath);
+                    String s3Key = s3Prefix + relativePath.toString().replace("\\", "/");
+
+                    // 파일 업로드
+                    uploadFile(filePath.toFile(), s3Key);
+                    successCount++;
+
+                } catch (Exception e) {
+                    log.error("파일 업로드 실패: {}", filePath, e);
+                }
+            }
+
+            log.info("디렉토리 업로드 완료: {}/{} 개 파일", successCount, files.size());
+            return successCount;
+
+        } catch (IOException e) {
+            log.error("디렉토리 스캔 실패: {}", localDir, e);
+            throw new RuntimeException("디렉토리 업로드 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 파일 삭제
+     *
+     * @param s3Key S3 키
+     */
+    public void deleteFile(String s3Key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제 완료: {}", s3Key);
+
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패: {}", s3Key, e);
+            throw new RuntimeException("S3 파일 삭제 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 디렉토리 전체 삭제
+     *
+     * @param s3Prefix S3 prefix
+     */
+    public void deleteDirectory(String s3Prefix) {
+        try {
+            // prefix로 시작하는 모든 객체 조회
+            ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(s3Prefix)
+                    .build();
+
+            ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+
+            if (listResponse.contents().isEmpty()) {
+                log.info("삭제할 파일 없음: {}", s3Prefix);
+                return;
+            }
+
+            // 모든 객체 삭제
+            List<ObjectIdentifier> objectsToDelete = listResponse.contents().stream()
+                    .map(s3Object -> ObjectIdentifier.builder()
+                            .key(s3Object.key())
+                            .build())
+                    .toList();
+
+            DeleteObjectsRequest deleteRequest = DeleteObjectsRequest.builder()
+                    .bucket(bucketName)
+                    .delete(Delete.builder().objects(objectsToDelete).build())
+                    .build();
+
+            s3Client.deleteObjects(deleteRequest);
+
+            log.info("S3 디렉토리 삭제 완료: {} ({} 개 파일)", s3Prefix, objectsToDelete.size());
+
+        } catch (Exception e) {
+            log.error("S3 디렉토리 삭제 실패: {}", s3Prefix, e);
+            throw new RuntimeException("S3 디렉토리 삭제 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 파일 존재 여부 확인
+     *
+     * @param s3Key S3 키
+     * @return 존재 여부
+     */
+    public boolean fileExists(String s3Key) {
+        try {
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+            return true;
+
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            log.error("S3 파일 존재 확인 실패: {}", s3Key, e);
+            throw new RuntimeException("S3 파일 존재 확인 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * CloudFront URL 생성
+     *
+     * @param s3Key S3 키
+     * @return CloudFront URL 또는 S3 URL
+     */
+    public String getUrl(String s3Key) {
+        if (cloudfrontDomain != null && !cloudfrontDomain.isEmpty()) {
+            return String.format("https://%s/%s", cloudfrontDomain, s3Key);
+        }
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucketName, region, s3Key);
+    }
+
+    /**
+     * Content-Type 결정
+     */
+    private String determineContentType(File file) {
+        String fileName = file.getName().toLowerCase();
+
+        if (fileName.endsWith(".m3u8")) {
+            return "application/vnd.apple.mpegurl";
+        } else if (fileName.endsWith(".ts")) {
+            return "video/mp2t";
+        } else if (fileName.endsWith(".mp4")) {
+            return "video/mp4";
+        } else if (fileName.endsWith(".jpg") || fileName.endsWith(".jpeg")) {
+            return "image/jpeg";
+        } else if (fileName.endsWith(".png")) {
+            return "image/png";
+        }
+
+        return "application/octet-stream";
+    }
+}

--- a/src/main/java/com/streamly/streamly/global/util/FileStorageUtil.java
+++ b/src/main/java/com/streamly/streamly/global/util/FileStorageUtil.java
@@ -39,6 +39,16 @@ public class FileStorageUtil {
      * @return 저장된 파일 경로
      */
     public String storeFile(MultipartFile file) {
+        return storeFile(file, null);
+    }
+
+    /**
+     * 파일 저장 (서브디렉토리 지원)
+     * @param file 업로드된 파일
+     * @param subDirectory 서브디렉토리 (예: "thumbnails")
+     * @return 저장된 파일 경로
+     */
+    public String storeFile(MultipartFile file, String subDirectory) {
         // 원본 파일명
         String originalFilename = file.getOriginalFilename();
         if (originalFilename == null || originalFilename.isEmpty()) {
@@ -50,8 +60,15 @@ public class FileStorageUtil {
         String storedFilename = UUID.randomUUID().toString() + extension;
 
         try {
+            // 서브디렉토리 처리
+            Path targetDirectory = this.uploadLocation;
+            if (subDirectory != null && !subDirectory.isEmpty()) {
+                targetDirectory = this.uploadLocation.resolve(subDirectory);
+                Files.createDirectories(targetDirectory);
+            }
+
             // 파일 저장
-            Path targetLocation = this.uploadLocation.resolve(storedFilename);
+            Path targetLocation = targetDirectory.resolve(storedFilename);
             Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
             
             log.info("파일 저장 완료: {} -> {}", originalFilename, storedFilename);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,20 @@ spring:
       max-file-size: 5GB      # 최대 파일 크기
       max-request-size: 5GB   # 최대 요청 크기
       file-size-threshold: 2MB # 메모리에 저장할 크기
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:admin}
+    password: ${RABBITMQ_PASSWORD:admin123}
+    listener:
+      simple:
+        concurrency: 3
+        max-concurrency: 10
+        retry:
+          enabled: true
+          initial-interval: 3000
+          max-attempts: 3
+          multiplier: 2
 
 jwt:
   secret: ${JWT_SECRET}  # 환경변수 필수 - 기본값 제거로 보안 강화
@@ -59,6 +73,27 @@ cookie:
 frontend:
   url: ${FRONTEND_URL:http://localhost:3000}
 
-# 파일 업로드 설정
-file:
-  upload-dir: ${FILE_UPLOAD_DIR:./uploads}
+# 영상 업로드 설정
+video:
+  upload:
+    directory: ${VIDEO_UPLOAD_DIR:uploads}
+  encoded:
+    directory: ${VIDEO_ENCODED_DIR:encoded}
+
+# FFmpeg 설정
+ffmpeg:
+  path: ${FFMPEG_PATH:ffmpeg}
+  
+# FFprobe 설정
+ffprobe:
+  path: ${FFPROBE_PATH:ffprobe}
+
+# AWS S3 설정
+aws:
+  access-key: ${AWS_ACCESS_KEY_ID}
+  secret-key: ${AWS_SECRET_ACCESS_KEY}
+  region: ${AWS_REGION:ap-northeast-2}
+  s3:
+    bucket-name: ${AWS_S3_BUCKET_NAME}
+  cloudfront:
+    domain: ${AWS_CLOUDFRONT_DOMAIN:}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #3 

## 📝 작업 내용
클라이언트가 영상을 업로드하면 RabbitMQ가 비동기적으로 FFmpeg 인코딩을 처리합니다.
인코딩 된 영상 파일과 썸네일은 1차적으로 로컬 스토리지에 저장합니다.
인코딩 파일을 S3에 마찬가지로 저장합니다.
클라이언트가 요청하면 영상을 CloudFront에서 전송합니다.
클라이언트가 영상을 삭제할 경우 모든 스토리지에서 영상을 삭제합니다.

> 작업내용 설명
TODO : 현재 영상을 업로드 할 경우 자동 승인이 되지만, 추후 관리자 기능을 도입하면 이를 변경해야 합니다.

### ✨ 스크린샷

### 💬 리뷰 요구사항
