### PR TITLE
fix : 광고 영상 카테고리 추가 및 누끼 이미지 조회 API 구현 (#37)

### DIFF
--- a/src/main/java/com/streamly/streamly/domain/advertiser/controller/AdVideoController.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/controller/AdVideoController.java
@@ -65,6 +65,17 @@ public class AdVideoController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "누끼 이미지 목록 조회")
+    @GetMapping("/{adVideoId}/nuki")
+    public ResponseEntity<AdVideoDto.NukiImagesResponse> getNukiImages(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long adVideoId) {
+
+        AdVideoDto.NukiImagesResponse response = adVideoService.getNukiImages(
+                userDetails.getUsername(), adVideoId);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "내 광고 영상 삭제")
     @DeleteMapping("/{adVideoId}")
     public ResponseEntity<String> deleteMyAdVideo(

--- a/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdNukiMessage.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdNukiMessage.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 @Builder
 public class AdNukiMessage implements Serializable {
     private Long adVideoId;
-    private String filePath;      // 로컬 저장된 광고 영상 경로
-    private String callbackUrl;   // AI 처리 완료 후 BE에 콜백할 URL
+    private String filePath;       // 로컬 저장된 광고 영상 경로
+    private String callbackUrl;    // AI 처리 완료 후 BE에 콜백할 URL
+    private String objectPrompt;   // SAM3 텍스트 프롬프트 (카테고리에서 변환)
 }

--- a/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdVideoDto.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdVideoDto.java
@@ -1,5 +1,6 @@
 package com.streamly.streamly.domain.advertiser.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.streamly.streamly.domain.advertiser.entity.AdObjectCategory;
 import com.streamly.streamly.domain.advertiser.entity.AdVideo;
 import lombok.*;
@@ -74,9 +75,12 @@ public class AdVideoDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class NukiCallbackRequest {
+        @JsonProperty("ad_video_id")
         private Long adVideoId;
         private boolean success;
-        private String nukiDirPath; // 처리 성공 시 누끼 저장 경로
-        private String failReason;  // 처리 실패 시 사유
+        @JsonProperty("nuki_dir_path")
+        private String nukiDirPath;
+        @JsonProperty("fail_reason")
+        private String failReason;
     }
 }

--- a/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdVideoDto.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdVideoDto.java
@@ -1,9 +1,11 @@
 package com.streamly.streamly.domain.advertiser.dto;
 
+import com.streamly.streamly.domain.advertiser.entity.AdObjectCategory;
 import com.streamly.streamly.domain.advertiser.entity.AdVideo;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class AdVideoDto {
 
@@ -14,6 +16,7 @@ public class AdVideoDto {
     public static class UploadRequest {
         private String title;
         private String description;
+        private String objectCategory;
     }
 
     // 목록/상세 응답
@@ -30,6 +33,7 @@ public class AdVideoDto {
         private String status;
         private String failReason;
         private String nukiDirPath;
+        private String objectCategory;
         private Long advertiserId;
         private String advertiserNickname;
         private LocalDateTime createdAt;
@@ -45,12 +49,24 @@ public class AdVideoDto {
                     .status(adVideo.getStatus().name())
                     .failReason(adVideo.getFailReason())
                     .nukiDirPath(adVideo.getNukiDirPath())
+                    .objectCategory(adVideo.getObjectCategory() != null ? adVideo.getObjectCategory().name() : null)
                     .advertiserId(adVideo.getAdvertiser().getId())
                     .advertiserNickname(adVideo.getAdvertiser().getNickname())
                     .createdAt(adVideo.getCreatedAt())
                     .updatedAt(adVideo.getUpdatedAt())
                     .build();
         }
+    }
+
+    // 누끼 이미지 목록 응답
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NukiImagesResponse {
+        private Long adVideoId;
+        private String status;
+        private List<String> imageUrls;
     }
 
     // AI 콜백 수신 (AI 서버 → BE)

--- a/src/main/java/com/streamly/streamly/domain/advertiser/entity/AdObjectCategory.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/entity/AdObjectCategory.java
@@ -1,0 +1,20 @@
+package com.streamly.streamly.domain.advertiser.entity;
+
+public enum AdObjectCategory {
+    FASHION, FOOD, ELECTRONICS, BEAUTY, FURNITURE, SPORTS, CAR, PET, BOOK, TOY;
+
+    public String toSam3Prompt() {
+        return switch (this) {
+            case FASHION     -> "clothing, shoes, bag, accessory";
+            case FOOD        -> "food, drink, beverage, bottle";
+            case ELECTRONICS -> "phone, laptop, electronic device, gadget";
+            case BEAUTY      -> "cosmetic, perfume, skincare product";
+            case FURNITURE   -> "furniture, chair, table, sofa";
+            case SPORTS      -> "sports equipment, ball, racket";
+            case CAR         -> "car, vehicle, automobile";
+            case PET         -> "pet, dog, cat, animal";
+            case BOOK        -> "book, magazine";
+            case TOY         -> "toy, doll, figure";
+        };
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/advertiser/entity/AdVideo.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/entity/AdVideo.java
@@ -47,6 +47,11 @@ public class AdVideo extends BaseEntity {
     @Builder.Default
     private AdVideoStatus status = AdVideoStatus.PENDING;
 
+    // 객체 카테고리 (SAM3 프롬프트 결정용)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "object_category")
+    private AdObjectCategory objectCategory;
+
     // AI 처리 실패 사유
     @Column(name = "fail_reason")
     private String failReason;

--- a/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
@@ -2,6 +2,7 @@ package com.streamly.streamly.domain.advertiser.service;
 
 import com.streamly.streamly.domain.advertiser.dto.AdNukiMessage;
 import com.streamly.streamly.domain.advertiser.dto.AdVideoDto;
+import com.streamly.streamly.domain.advertiser.entity.AdObjectCategory;
 import com.streamly.streamly.domain.advertiser.entity.AdVideo;
 import com.streamly.streamly.domain.advertiser.repository.AdVideoRepository;
 import com.streamly.streamly.domain.user.entity.User;
@@ -24,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -42,6 +44,12 @@ public class AdVideoService {
     @Value("${ad.callback.url:http://localhost:8080/api/v1/advertiser/callback/nuki}")
     private String callbackUrl;
 
+    @Value("${ad.nuki.directory:C:/ItWorks/nuki_results}")
+    private String nukiDirectory;
+
+    @Value("${server.url:http://localhost:8080}")
+    private String serverUrl;
+
     /**
      * 광고 영상 업로드 - C:/ItWorks/uploads/advideos/{uuid}/{원본파일명} 저장
      */
@@ -52,12 +60,14 @@ public class AdVideoService {
 
         validateVideoFile(videoFile);
 
+        AdObjectCategory category = parseCategory(request.getObjectCategory());
         String savedFilePath = storeAdVideo(videoFile);
 
         AdVideo adVideo = AdVideo.builder()
                 .advertiser(advertiser)
                 .title(request.getTitle())
                 .description(request.getDescription())
+                .objectCategory(category)
                 .originalFilename(videoFile.getOriginalFilename())
                 .originalFileSize(videoFile.getSize())
                 .filePath(savedFilePath)
@@ -65,11 +75,14 @@ public class AdVideoService {
 
         AdVideo saved = adVideoRepository.save(adVideo);
 
+        String objectPrompt = category != null ? category.toSam3Prompt() : "object";
+
         // AI 서버에 누끼 처리 요청 (RabbitMQ 비동기)
         AdNukiMessage message = AdNukiMessage.builder()
                 .adVideoId(saved.getId())
                 .filePath(savedFilePath)
                 .callbackUrl(callbackUrl)
+                .objectPrompt(objectPrompt)
                 .build();
 
         rabbitTemplate.convertAndSend(
@@ -175,6 +188,56 @@ public class AdVideoService {
         }
 
         adVideoRepository.save(adVideo);
+    }
+
+    /**
+     * 누끼 이미지 목록 조회 - nukiDirPath 내 PNG 파일을 URL로 변환해 반환
+     */
+    @Transactional(readOnly = true)
+    public AdVideoDto.NukiImagesResponse getNukiImages(String email, Long adVideoId) {
+        User advertiser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        AdVideo adVideo = adVideoRepository.findById(adVideoId)
+                .orElseThrow(() -> new IllegalArgumentException("광고 영상을 찾을 수 없습니다."));
+
+        validateOwnership(adVideo, advertiser.getId());
+
+        if (adVideo.getNukiDirPath() == null) {
+            return AdVideoDto.NukiImagesResponse.builder()
+                    .adVideoId(adVideoId)
+                    .status(adVideo.getStatus().name())
+                    .imageUrls(List.of())
+                    .build();
+        }
+
+        List<String> imageUrls;
+        try (Stream<Path> files = Files.list(Paths.get(adVideo.getNukiDirPath()))) {
+            imageUrls = files
+                    .filter(p -> p.toString().toLowerCase().endsWith(".png"))
+                    .sorted()
+                    .map(p -> serverUrl + "/nuki/" + adVideoId + "/" + p.getFileName().toString())
+                    .toList();
+        } catch (IOException e) {
+            log.warn("누끼 이미지 디렉토리 읽기 실패 - adVideoId: {}, path: {}", adVideoId, adVideo.getNukiDirPath(), e);
+            imageUrls = List.of();
+        }
+
+        return AdVideoDto.NukiImagesResponse.builder()
+                .adVideoId(adVideoId)
+                .status(adVideo.getStatus().name())
+                .imageUrls(imageUrls)
+                .build();
+    }
+
+    private AdObjectCategory parseCategory(String categoryStr) {
+        if (categoryStr == null || categoryStr.isBlank()) return null;
+        try {
+            return AdObjectCategory.valueOf(categoryStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("알 수 없는 카테고리: {}", categoryStr);
+            return null;
+        }
     }
 
     private void validateOwnership(AdVideo adVideo, Long userId) {

--- a/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
@@ -4,6 +4,7 @@ import com.streamly.streamly.domain.advertiser.dto.AdNukiMessage;
 import com.streamly.streamly.domain.advertiser.dto.AdVideoDto;
 import com.streamly.streamly.domain.advertiser.entity.AdObjectCategory;
 import com.streamly.streamly.domain.advertiser.entity.AdVideo;
+import com.streamly.streamly.domain.advertiser.entity.AdVideoStatus;
 import com.streamly.streamly.domain.advertiser.repository.AdVideoRepository;
 import com.streamly.streamly.domain.user.entity.User;
 import com.streamly.streamly.domain.user.repository.UserRepository;
@@ -85,11 +86,18 @@ public class AdVideoService {
                 .objectPrompt(objectPrompt)
                 .build();
 
-        rabbitTemplate.convertAndSend(
-                RabbitMQConfig.AD_NUKI_EXCHANGE,
-                RabbitMQConfig.AD_NUKI_ROUTING_KEY,
-                message
-        );
+        try {
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.AD_NUKI_EXCHANGE,
+                    RabbitMQConfig.AD_NUKI_ROUTING_KEY,
+                    message
+            );
+            saved.markProcessing();
+        } catch (Exception e) {
+            log.error("RabbitMQ 발행 실패 - adVideoId: {}", saved.getId(), e);
+            try { deleteDirectory(Paths.get(savedFilePath).getParent()); } catch (Exception ignored) {}
+            throw new RuntimeException("AI 처리 요청에 실패했습니다. 잠시 후 다시 시도해주세요.", e);
+        }
 
         log.info("광고 영상 업로드 완료 - adVideoId: {}, path: {}, advertiser: {}",
                 saved.getId(), savedFilePath, email);
@@ -176,6 +184,12 @@ public class AdVideoService {
     public void handleNukiCallback(AdVideoDto.NukiCallbackRequest callback) {
         AdVideo adVideo = adVideoRepository.findById(callback.getAdVideoId())
                 .orElseThrow(() -> new IllegalArgumentException("광고 영상을 찾을 수 없습니다."));
+
+        // 이미 종료 상태면 중복 콜백 무시 (멱등성 보장)
+        if (adVideo.getStatus() == AdVideoStatus.DONE || adVideo.getStatus() == AdVideoStatus.FAILED) {
+            log.warn("중복 콜백 수신 무시 - adVideoId: {}, 현재상태: {}", callback.getAdVideoId(), adVideo.getStatus());
+            return;
+        }
 
         if (callback.isSuccess()) {
             adVideo.markDone(callback.getNukiDirPath());

--- a/src/main/java/com/streamly/streamly/global/config/SecurityConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/test/**").permitAll()
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll()
                         .requestMatchers("/api/v1/auth/refresh").permitAll()
-                        .requestMatchers("/thumbnails/**", "/uploads/**", "/encoded/**").permitAll()
+                        .requestMatchers("/thumbnails/**", "/uploads/**", "/encoded/**", "/nuki/**").permitAll()
                         // [수정] Actuator 경로도 접두사 포함 허용
                         .requestMatchers("/actuator/**", "/api/actuator/**").permitAll()
                         .requestMatchers("/api/v1/users/me").authenticated()

--- a/src/main/java/com/streamly/streamly/global/config/WebConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/WebConfig.java
@@ -22,6 +22,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${video.encoded.directory:./encoded}")
     private String encodedDir;
 
+    @Value("${ad.nuki.directory:C:/ItWorks/nuki_results}")
+    private String nukiDir;
+
     /**
      * CORS 설정
      */
@@ -43,6 +46,13 @@ public class WebConfig implements WebMvcConfigurer {
                 .maxAge(3600);
 
         registry.addMapping("/thumbnails/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+
+        registry.addMapping("/nuki/**")
                 .allowedOrigins("http://localhost:3000")
                 .allowedMethods("GET", "OPTIONS")
                 .allowedHeaders("*")
@@ -76,6 +86,17 @@ public class WebConfig implements WebMvcConfigurer {
 
         registry.addResourceHandler("/uploads/**")
                 .addResourceLocations(uploadPath)
+                .setCachePeriod(3600);
+
+        // 누끼 이미지 경로 설정 (/nuki/{adVideoId}/{filename})
+        String nukiPath = Paths.get(nukiDir)
+                .toAbsolutePath()
+                .normalize()
+                .toUri()
+                .toString();
+
+        registry.addResourceHandler("/nuki/**")
+                .addResourceLocations(nukiPath)
                 .setCachePeriod(3600);
 
         // 인코딩된 HLS 파일 경로 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,6 +83,10 @@ cookie:
 frontend:
   url: ${FRONTEND_URL:http://localhost:3000}
 
+# --- 서버 URL ---
+server:
+  url: ${SERVER_URL:http://localhost:8080}
+
 # --- 영상 처리 경로 ---
 video:
   upload:
@@ -95,6 +99,16 @@ ffmpeg:
   path: ${FFMPEG_PATH:ffmpeg}
 ffprobe:
   path: ${FFPROBE_PATH:ffprobe}
+
+# --- 광고 영상 처리 ---
+ad:
+  video:
+    upload:
+      directory: ${AD_VIDEO_DIR:C:/ItWorks/uploads/advideos}
+  nuki:
+    directory: ${AD_NUKI_DIR:C:/ItWorks/nuki_results}
+  callback:
+    url: ${AD_CALLBACK_URL:http://localhost:8080/api/v1/advertiser/callback/nuki}
 
 # --- AWS S3 ---
 aws:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #37

## 📝 작업 내용
> - `AdVideoDto.NukiCallbackRequest`에 `@JsonProperty` 어노테이션 추가 — AI 서버 snake_case 응답 역직렬화 오류 수정
> - RabbitMQ 메시지 발행 실패 시 파일 정리 및 사용자에게 명확한 오류 메시지 반환
> - `handleNukiCallback` 멱등성 처리 추가 — 이미 DONE/FAILED 상태인 경우 중복 콜백 무시
> - `markProcessing()` 호출을 RabbitMQ 발행 성공 이후로 이동

### ✨ 스크린샷

### 💬 리뷰 요구사항