### PR TITLE
feature : 특정 영상의 광고 정보를 반환하는 엔드포인트 추가 및 광고 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'

--- a/src/main/java/com/streamly/streamly/domain/advertiser/controller/AdVideoController.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/controller/AdVideoController.java
@@ -18,6 +18,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @Tag(name = "광고주 영상 API", description = "광고주 본인 영상 관리 API")
 @Slf4j
 @RestController
@@ -33,11 +35,12 @@ public class AdVideoController {
     public ResponseEntity<AdVideoDto.Response> uploadAdVideo(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestPart("request") AdVideoDto.UploadRequest request,
-            @RequestPart("videoFile") MultipartFile videoFile) {
+            @RequestPart("videoFile") MultipartFile videoFile,
+            @RequestPart("adImageFile") MultipartFile adImageFile) throws IOException {
 
         log.info("광고 영상 업로드 요청 - user: {}", userDetails.getUsername());
         AdVideoDto.Response response = adVideoService.uploadAdVideo(
-                userDetails.getUsername(), request, videoFile);
+                userDetails.getUsername(), request, videoFile, adImageFile);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdVideoDto.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/dto/AdVideoDto.java
@@ -34,6 +34,7 @@ public class AdVideoDto {
         private String status;
         private String failReason;
         private String nukiDirPath;
+        private String adImagePath;
         private String objectCategory;
         private Long advertiserId;
         private String advertiserNickname;
@@ -50,6 +51,7 @@ public class AdVideoDto {
                     .status(adVideo.getStatus().name())
                     .failReason(adVideo.getFailReason())
                     .nukiDirPath(adVideo.getNukiDirPath())
+                    .adImagePath(adVideo.getAdImagePath())
                     .objectCategory(adVideo.getObjectCategory() != null ? adVideo.getObjectCategory().name() : null)
                     .advertiserId(adVideo.getAdvertiser().getId())
                     .advertiserNickname(adVideo.getAdvertiser().getNickname())

--- a/src/main/java/com/streamly/streamly/domain/advertiser/entity/AdVideo.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/entity/AdVideo.java
@@ -60,6 +60,9 @@ public class AdVideo extends BaseEntity {
     @Column(name = "nuki_dir_path")
     private String nukiDirPath;
 
+    @Column(name = "ad_image_path")
+    private String adImagePath;
+
     // 비즈니스 메서드
     public void markProcessing() {
         this.status = AdVideoStatus.PROCESSING;

--- a/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
@@ -42,6 +42,9 @@ public class AdVideoService {
     @Value("${ad.video.upload.directory:C:/ItWorks/uploads/advideos}")
     private String adUploadDirectory;
 
+    @Value("${video.upload.directory:uploads}")
+    private String uploadDirectory;
+
     @Value("${ad.callback.url:http://localhost:8080/api/v1/advertiser/callback/nuki}")
     private String callbackUrl;
 
@@ -55,7 +58,7 @@ public class AdVideoService {
      * 광고 영상 업로드 - C:/ItWorks/uploads/advideos/{uuid}/{원본파일명} 저장
      */
     @Transactional
-    public AdVideoDto.Response uploadAdVideo(String email, AdVideoDto.UploadRequest request, MultipartFile videoFile) {
+    public AdVideoDto.Response uploadAdVideo(String email, AdVideoDto.UploadRequest request, MultipartFile videoFile, MultipartFile imageFile) throws IOException {
         User advertiser = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -63,6 +66,12 @@ public class AdVideoService {
 
         AdObjectCategory category = parseCategory(request.getObjectCategory());
         String savedFilePath = storeAdVideo(videoFile);
+
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new IllegalArgumentException("광고 이미지 파일은 필수입니다.");
+        }
+        String adImageUrl = saveAdImageLocally(imageFile);
+        log.info("Ad image saved locally: {}", adImageUrl);
 
         AdVideo adVideo = AdVideo.builder()
                 .advertiser(advertiser)
@@ -72,6 +81,7 @@ public class AdVideoService {
                 .originalFilename(videoFile.getOriginalFilename())
                 .originalFileSize(videoFile.getSize())
                 .filePath(savedFilePath)
+                .adImagePath(adImageUrl)
                 .build();
 
         AdVideo saved = adVideoRepository.save(adVideo);
@@ -251,26 +261,6 @@ public class AdVideoService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
-    public String getFirstNukiImageUrl(Long adVideoId) {
-        AdVideo adVideo = adVideoRepository.findById(adVideoId)
-                .orElseThrow(() -> new IllegalArgumentException("광고 영상을 찾을 수 없습니다."));
-
-        if (adVideo.getNukiDirPath() == null) return null;
-
-        try (Stream<Path> files = Files.list(Paths.get(adVideo.getNukiDirPath()))) {
-            return files
-                    .filter(p -> p.toString().toLowerCase().endsWith(".png"))
-                    .sorted()
-                    .map(p -> serverUrl + "/nuki/" + adVideoId + "/" + p.getFileName().toString())
-                    .findFirst()
-                    .orElse(null);
-        } catch (IOException e) {
-            log.warn("누끼 이미지 디렉토리 읽기 실패 - adVideoId: {}, path: {}", adVideoId, adVideo.getNukiDirPath(), e);
-            return null;
-        }
-    }
-
     private AdObjectCategory parseCategory(String categoryStr) {
         if (categoryStr == null || categoryStr.isBlank()) return null;
         try {
@@ -334,5 +324,29 @@ public class AdVideoService {
                 });
             }
         }
+    }
+
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+
+    private String saveAdImageLocally(MultipartFile imageFile) throws IOException {
+        String originalFileName = imageFile.getOriginalFilename();
+        String uniqueFileName = UUID.randomUUID().toString() + getFileExtension(originalFileName);
+
+        Path adImageDir = Paths.get(uploadDirectory, "adImages");
+        if (!Files.exists(adImageDir)) {
+            Files.createDirectories(adImageDir);
+        }
+
+        Path targetPath = adImageDir.resolve(uniqueFileName);
+        Files.copy(imageFile.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+        log.info("Ad image saved locally: {}", targetPath);
+
+        return "/adImages/" + uniqueFileName;
     }
 }

--- a/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/advertiser/service/AdVideoService.java
@@ -158,6 +158,13 @@ public class AdVideoService {
         return AdVideoDto.Response.from(adVideo);
     }
 
+    @Transactional(readOnly = true)
+    public AdVideoDto.Response getAdVideoById(Long adVideoId) {
+        AdVideo adVideo = adVideoRepository.findById(adVideoId)
+                .orElseThrow(() -> new IllegalArgumentException("광고 영상을 찾을 수 없습니다."));
+        return AdVideoDto.Response.from(adVideo);
+    }
+
     /**
      * 내 광고 영상 삭제 - 파일 및 누끼 결과 모두 삭제 (본인 소유 검증 포함)
      */
@@ -242,6 +249,26 @@ public class AdVideoService {
                 .status(adVideo.getStatus().name())
                 .imageUrls(imageUrls)
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public String getFirstNukiImageUrl(Long adVideoId) {
+        AdVideo adVideo = adVideoRepository.findById(adVideoId)
+                .orElseThrow(() -> new IllegalArgumentException("광고 영상을 찾을 수 없습니다."));
+
+        if (adVideo.getNukiDirPath() == null) return null;
+
+        try (Stream<Path> files = Files.list(Paths.get(adVideo.getNukiDirPath()))) {
+            return files
+                    .filter(p -> p.toString().toLowerCase().endsWith(".png"))
+                    .sorted()
+                    .map(p -> serverUrl + "/nuki/" + adVideoId + "/" + p.getFileName().toString())
+                    .findFirst()
+                    .orElse(null);
+        } catch (IOException e) {
+            log.warn("누끼 이미지 디렉토리 읽기 실패 - adVideoId: {}, path: {}", adVideoId, adVideo.getNukiDirPath(), e);
+            return null;
+        }
     }
 
     private AdObjectCategory parseCategory(String categoryStr) {

--- a/src/main/java/com/streamly/streamly/domain/interaction/service/FavoritesService.java
+++ b/src/main/java/com/streamly/streamly/domain/interaction/service/FavoritesService.java
@@ -35,8 +35,8 @@ public class FavoritesService {
     public boolean checkFavorite(String email, Long videoId) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-        if (videoRepository.existsById(videoId)) {
-            throw new VideoNotFoundException("영상을 찾을 수 없습니다.");
+        if (!videoRepository.existsById(videoId)) {
+            return false;
         }
         return favoritesRepository.existsByUserIdAndVideoId(user.getId(), videoId);
     }

--- a/src/main/java/com/streamly/streamly/domain/video/controller/VideoController.java
+++ b/src/main/java/com/streamly/streamly/domain/video/controller/VideoController.java
@@ -30,7 +30,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class VideoController {
 
     private final VideoService videoService;
-    private final AiVideoService aiVideoService;
     private final PlaylistResolverService playlistResolverService;
 
     @Operation(

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
@@ -45,14 +45,13 @@ public class VideoCompositionController {
             return ResponseEntity.ok(AdInfoDto.noAd());
         }
         AdVideoDto.Response adVideoById = adVideoService.getAdVideoById(videoComposition.getAdVideoId());
-        String nukiImageUrl = adVideoService.getFirstNukiImageUrl(videoComposition.getAdVideoId());
 
         return ResponseEntity.ok(AdInfoDto.from(
                 true,
                 videoComposition.getAdVideoId(),
                 adVideoById.getAdvertiserNickname(),
                 adVideoById.getDescription(),
-                nukiImageUrl
+                adVideoById.getAdImagePath()
         ));
     }
 

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
@@ -1,9 +1,14 @@
 package com.streamly.streamly.domain.videoComposition.controller;
 
+import com.streamly.streamly.domain.advertiser.dto.AdVideoDto;
+import com.streamly.streamly.domain.advertiser.service.AdVideoService;
+import com.streamly.streamly.domain.user.repository.UserRepository;
 import com.streamly.streamly.domain.video.dto.AiFetchResponse;
 import com.streamly.streamly.domain.video.service.AiVideoService;
+import com.streamly.streamly.domain.videoComposition.dto.AdInfoDto;
 import com.streamly.streamly.domain.videoComposition.dto.VideoCompositionDto;
 import com.streamly.streamly.domain.videoComposition.dto.VideoCompositionStatusResponse;
+import com.streamly.streamly.domain.videoComposition.entity.VideoComposition;
 import com.streamly.streamly.domain.videoComposition.service.VideoCompositionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,6 +31,30 @@ public class VideoCompositionController {
 
     private final AiVideoService aiVideoService;
     private final VideoCompositionService videoCompositionService;
+    private final AdVideoService adVideoService;
+
+
+    @GetMapping("/{videoId}/ad-info")
+    public ResponseEntity<AdInfoDto> getAdInfo(
+            @PathVariable Long videoId
+    ){
+        VideoComposition videoComposition = videoCompositionService.getCurrentVideoComposition(videoId)
+                .orElse(null);
+
+        if (videoComposition == null) {
+            return ResponseEntity.ok(AdInfoDto.noAd());
+        }
+        AdVideoDto.Response adVideoById = adVideoService.getAdVideoById(videoComposition.getAdVideoId());
+        String nukiImageUrl = adVideoService.getFirstNukiImageUrl(videoComposition.getAdVideoId());
+
+        return ResponseEntity.ok(AdInfoDto.from(
+                true,
+                videoComposition.getAdVideoId(),
+                adVideoById.getAdvertiserNickname(),
+                adVideoById.getDescription(),
+                nukiImageUrl
+        ));
+    }
 
     // -------------------------------------------------------------------------
     // Uploader — request AI composition

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/dto/AdInfoDto.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/dto/AdInfoDto.java
@@ -1,0 +1,35 @@
+package com.streamly.streamly.domain.videoComposition.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdInfoDto {
+    private boolean hasAd;
+    private Long adVideoId;
+    private String advertiserName;
+    private String description;
+    private String nukiImageUrl;
+
+    public static AdInfoDto from(boolean hasAd, Long adVideoId, String advertiserName, String description, String nukiImageUrl) {
+        return AdInfoDto.builder()
+                .hasAd(hasAd)
+                .adVideoId(adVideoId)
+                .advertiserName(advertiserName)
+                .description(description)
+                .nukiImageUrl(nukiImageUrl)
+                .build();
+    }
+
+    public static AdInfoDto noAd() {
+        return AdInfoDto.builder()
+                .hasAd(false)
+                .build();
+    }
+}

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/service/VideoCompositionService.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/service/VideoCompositionService.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -31,6 +33,11 @@ public class VideoCompositionService {
     private final HeartbeatStore heartbeatStore;
     private final CompositionStatusPromoter statusPromoter;
     private final ObjectMapper objectMapper;
+
+    public Optional<VideoComposition> getCurrentVideoComposition(Long videoId) {
+        return videoCompositionRepository
+                .findFirstByVideoIdAndStatusAndApprovalStatusOrderByPublishedAtDesc(videoId, CompositionStatus.COMPLETED, AdvertiserApprovalStatus.APPROVED);
+    }
 
     // -------------------------------------------------------------------------
     // Advertiser — list pending compositions

--- a/src/main/java/com/streamly/streamly/global/config/WebConfig.java
+++ b/src/main/java/com/streamly/streamly/global/config/WebConfig.java
@@ -25,6 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${ad.nuki.directory:C:/ItWorks/nuki_results}")
     private String nukiDir;
 
+
     /**
      * CORS 설정
      */
@@ -53,6 +54,13 @@ public class WebConfig implements WebMvcConfigurer {
                 .maxAge(3600);
 
         registry.addMapping("/nuki/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+
+        registry.addMapping("/adImages/**")
                 .allowedOrigins("http://localhost:3000")
                 .allowedMethods("GET", "OPTIONS")
                 .allowedHeaders("*")
@@ -97,6 +105,17 @@ public class WebConfig implements WebMvcConfigurer {
 
         registry.addResourceHandler("/nuki/**")
                 .addResourceLocations(nukiPath)
+                .setCachePeriod(3600);
+
+        // 광고 이미지 경로 설정 (/adImages/{filename})
+        String adImagePath = Paths.get(uploadDir, "adImages")
+                .toAbsolutePath()
+                .normalize()
+                .toUri()
+                .toString();
+
+        registry.addResourceHandler("/adImages/**")
+                .addResourceLocations(adImagePath)
                 .setCachePeriod(3600);
 
         // 인코딩된 HLS 파일 경로 설정


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #49 

## 📝 작업 내용
1. VideoCompositionController에 GET /{videoId}/ad-info 엔드포인트 추가
     - 특정 비디오의 광고 정보를 포함한 AdInfoDto를 반환합니다.
     - 연결된 광고가 없을 경우, hasAd: false 형태의 응답을 반환합니다.

2. 영상 thumbnail과 같은 방식/구조로 광고 영상 업로드 시에 광고 이미지를 필수적으로 업로드하게 합니다.
     -  로컬 기준으로 C:/ItWorks/uploads/adImages에 광고 이미지를 저장합니다.
   
3. VideoCompositionService에 getCurrentVideoComposition 메서드 추가
     - 특정 비디오에 대해 COMPLETED 및 APPROVED 상태인 최신 Composition         을 조회합니다.

### ✨ 스크린샷

### 💬 리뷰 요구사항
