### PR TITLE
feature : 바운딩 박스 좌표 전달 구현

### DIFF
--- a/db/alter_video_compositions_bounding_box.sql
+++ b/db/alter_video_compositions_bounding_box.sql
@@ -1,0 +1,19 @@
+-- video_compositions: 객체 지정 방식을 텍스트 프롬프트/포인트 → 단일 바운딩 박스로 변경
+--
+-- 배경: JPA ddl-auto=update 는 "이미 행이 존재하는 테이블"에 default 없는 NOT NULL 컬럼을
+-- 추가하지 못한다. 그래서 bounding_box(json, NOT NULL) 컬럼이 생성되지 않아 INSERT 가
+-- "column bounding_box does not exist" 로 실패한다. 또한 엔티티에서 제거된 object_prompt
+-- (NOT NULL) 컬럼이 테이블에 남아 있으면, bounding_box 를 추가해도 INSERT 가 이번엔
+-- object_prompt NOT NULL 제약으로 실패한다. 아래를 한 번 실행해 스키마를 정렬한다.
+--
+-- 주의: 기존 행에는 새 스키마({x,y,width,height}) 값이 없으므로 '{}' 로 채운다.
+
+-- PostgreSQL
+ALTER TABLE video_compositions ADD COLUMN IF NOT EXISTS bounding_box json;
+UPDATE video_compositions SET bounding_box = '{}'::json WHERE bounding_box IS NULL;
+ALTER TABLE video_compositions ALTER COLUMN bounding_box SET NOT NULL;
+
+-- 엔티티에서 제거된 구 컬럼 정리 (존재할 때만)
+ALTER TABLE video_compositions DROP COLUMN IF EXISTS object_prompt;
+-- 과거 points 실험으로 click_points 가 남아 있다면 함께 제거
+ALTER TABLE video_compositions DROP COLUMN IF EXISTS click_points;

--- a/src/main/java/com/streamly/streamly/domain/video/dto/VideoComposeMessage.java
+++ b/src/main/java/com/streamly/streamly/domain/video/dto/VideoComposeMessage.java
@@ -1,10 +1,9 @@
 package com.streamly.streamly.domain.video.dto;
 
-import com.streamly.streamly.domain.videoComposition.entity.ClickPoint;
+import com.streamly.streamly.domain.videoComposition.entity.BoundingBox;
 import lombok.*;
 
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * RabbitMQ로 AI 서버에 전달하는 영상 fetch 요청 메시지
@@ -14,23 +13,23 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class VideoComposeMessage implements Serializable {
-    private Long    videoId;
-    private String  videoUrl;
-    private String  startTime;
-    private Integer duration;
-    private List<ClickPoint>points;
-    private String  callbackUrl; // AI 처리 완료 후 BE에 콜백할 URL
+    private Long        videoId;
+    private String      videoUrl;
+    private String      startTime;
+    private Integer     duration;
+    private BoundingBox boundingBox;
+    private String      callbackUrl; // AI 처리 완료 후 BE에 콜백할 URL
 
     /**
      * compositionId 확보 전 초안 — callbackUrl은 빈 문자열로 저장 후 교체
      */
-    public static VideoComposeMessage draft(Long videoId, String videoUrl, String startTime, Integer duration, List<ClickPoint>points) {
+    public static VideoComposeMessage draft(Long videoId, String videoUrl, String startTime, Integer duration, BoundingBox boundingBox) {
         return VideoComposeMessage.builder()
                 .videoId(videoId)
                 .videoUrl(videoUrl)
                 .startTime(startTime != null ? startTime : "00:00:00")
                 .duration(duration)
-                .points(points)
+                .boundingBox(boundingBox)
                 .callbackUrl("")
                 .build();
     }
@@ -44,7 +43,7 @@ public class VideoComposeMessage implements Serializable {
                 .videoUrl(draft.videoUrl)
                 .startTime(draft.startTime)
                 .duration(draft.duration)
-                .points(draft.points)
+                .boundingBox(draft.boundingBox)
                 .callbackUrl(callbackUrl)
                 .build();
     }

--- a/src/main/java/com/streamly/streamly/domain/video/dto/VideoComposeMessage.java
+++ b/src/main/java/com/streamly/streamly/domain/video/dto/VideoComposeMessage.java
@@ -1,8 +1,10 @@
 package com.streamly.streamly.domain.video.dto;
 
+import com.streamly.streamly.domain.videoComposition.entity.ClickPoint;
 import lombok.*;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * RabbitMQ로 AI 서버에 전달하는 영상 fetch 요청 메시지
@@ -16,19 +18,19 @@ public class VideoComposeMessage implements Serializable {
     private String  videoUrl;
     private String  startTime;
     private Integer duration;
-    private String  objectPrompt;
+    private List<ClickPoint>points;
     private String  callbackUrl; // AI 처리 완료 후 BE에 콜백할 URL
 
     /**
      * compositionId 확보 전 초안 — callbackUrl은 빈 문자열로 저장 후 교체
      */
-    public static VideoComposeMessage draft(Long videoId, String videoUrl, String startTime, Integer duration, String objectPrompt) {
+    public static VideoComposeMessage draft(Long videoId, String videoUrl, String startTime, Integer duration, List<ClickPoint>points) {
         return VideoComposeMessage.builder()
                 .videoId(videoId)
                 .videoUrl(videoUrl)
                 .startTime(startTime != null ? startTime : "00:00:00")
                 .duration(duration)
-                .objectPrompt(objectPrompt)
+                .points(points)
                 .callbackUrl("")
                 .build();
     }
@@ -42,7 +44,7 @@ public class VideoComposeMessage implements Serializable {
                 .videoUrl(draft.videoUrl)
                 .startTime(draft.startTime)
                 .duration(draft.duration)
-                .objectPrompt(draft.objectPrompt)
+                .points(draft.points)
                 .callbackUrl(callbackUrl)
                 .build();
     }

--- a/src/main/java/com/streamly/streamly/domain/video/service/AiVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/video/service/AiVideoService.java
@@ -6,7 +6,7 @@ import com.streamly.streamly.domain.user.repository.UserRepository;
 import com.streamly.streamly.domain.video.dto.VideoComposeMessage;
 import com.streamly.streamly.domain.video.entity.Video;
 import com.streamly.streamly.domain.video.repository.VideoRepository;
-import com.streamly.streamly.domain.videoComposition.entity.ClickPoint;
+import com.streamly.streamly.domain.videoComposition.entity.BoundingBox;
 import com.streamly.streamly.domain.videoComposition.service.VideoCompositionService;
 import com.streamly.streamly.global.config.RabbitMQConfig;
 import com.streamly.streamly.global.exception.BusinessException;
@@ -18,8 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -34,7 +32,7 @@ public class AiVideoService {
     @Value("${server.base-url:http://localhost:8080}")
     private String beServerUrl;
 
-    public Long requestAiComposition(String requesterEmail, Long videoId, String startTime, Integer duration, List<ClickPoint> points) {
+    public Long requestAiComposition(String requesterEmail, Long videoId, String startTime, Integer duration, BoundingBox boundingBox) {
         User requester = userRepository.findByEmail(requesterEmail)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -55,7 +53,7 @@ public class AiVideoService {
         }
         String videoUrl = rawUrl.startsWith("/") ? beServerUrl + rawUrl : rawUrl;
 
-        VideoComposeMessage draft = VideoComposeMessage.draft(videoId, videoUrl, startTime, duration, points);
+        VideoComposeMessage draft = VideoComposeMessage.draft(videoId, videoUrl, startTime, duration, boundingBox);
         Long compositionId = videoCompositionService.initialSave(draft);
 
         String callbackUrl = beServerUrl + "/api/v1/video-compositions/" + compositionId + "/callback";

--- a/src/main/java/com/streamly/streamly/domain/video/service/AiVideoService.java
+++ b/src/main/java/com/streamly/streamly/domain/video/service/AiVideoService.java
@@ -6,6 +6,7 @@ import com.streamly.streamly.domain.user.repository.UserRepository;
 import com.streamly.streamly.domain.video.dto.VideoComposeMessage;
 import com.streamly.streamly.domain.video.entity.Video;
 import com.streamly.streamly.domain.video.repository.VideoRepository;
+import com.streamly.streamly.domain.videoComposition.entity.ClickPoint;
 import com.streamly.streamly.domain.videoComposition.service.VideoCompositionService;
 import com.streamly.streamly.global.config.RabbitMQConfig;
 import com.streamly.streamly.global.exception.BusinessException;
@@ -17,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -31,7 +34,7 @@ public class AiVideoService {
     @Value("${server.base-url:http://localhost:8080}")
     private String beServerUrl;
 
-    public Long requestAiComposition(String requesterEmail, Long videoId, String startTime, Integer duration, String objectPrompt) {
+    public Long requestAiComposition(String requesterEmail, Long videoId, String startTime, Integer duration, List<ClickPoint> points) {
         User requester = userRepository.findByEmail(requesterEmail)
                 .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -52,7 +55,7 @@ public class AiVideoService {
         }
         String videoUrl = rawUrl.startsWith("/") ? beServerUrl + rawUrl : rawUrl;
 
-        VideoComposeMessage draft = VideoComposeMessage.draft(videoId, videoUrl, startTime, duration, objectPrompt);
+        VideoComposeMessage draft = VideoComposeMessage.draft(videoId, videoUrl, startTime, duration, points);
         Long compositionId = videoCompositionService.initialSave(draft);
 
         String callbackUrl = beServerUrl + "/api/v1/video-compositions/" + compositionId + "/callback";

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
@@ -8,10 +8,12 @@ import com.streamly.streamly.domain.video.service.AiVideoService;
 import com.streamly.streamly.domain.videoComposition.dto.AdInfoDto;
 import com.streamly.streamly.domain.videoComposition.dto.VideoCompositionDto;
 import com.streamly.streamly.domain.videoComposition.dto.VideoCompositionStatusResponse;
+import com.streamly.streamly.domain.videoComposition.entity.AiCompositionRequest;
 import com.streamly.streamly.domain.videoComposition.entity.VideoComposition;
 import com.streamly.streamly.domain.videoComposition.service.VideoCompositionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -59,6 +61,27 @@ public class VideoCompositionController {
     // Uploader — request AI composition
     // -------------------------------------------------------------------------
 
+//    @Operation(
+//            summary = "AI 합성 요청",
+//            description = "AI 서버에 특정 영상 구간의 객체 탐지 및 합성을 요청합니다."
+//    )
+//    @PreAuthorize("hasAnyRole('UPLOADER', 'ADMIN')")
+//    @PostMapping("/{videoId}/ai-fetch")
+//    public ResponseEntity<Map<String, Long>> queueAiComposition(
+//            @Parameter(hidden = true) Authentication authentication,
+//            @Parameter(description = "영상 ID", required = true)
+//            @PathVariable Long videoId,
+//            @Parameter(description = "시작 시간 (HH:mm:ss, 기본값: 00:00:00)")
+//            @RequestParam(defaultValue = "00:00:00") String startTime,
+//            @Parameter(description = "구간 길이(초), 미입력 시 끝까지")
+//            @RequestParam(required = false) Integer duration,
+//            @Parameter(description = "객체 탐지 프롬프트", required = true)
+//            @RequestParam String objectPrompt) {
+//
+//        String requesterEmail = authentication.getName();
+//        Long compositionId = aiVideoService.requestAiComposition(requesterEmail, videoId, startTime, duration, objectPrompt);
+//        return ResponseEntity.accepted().body(Map.of("compositionId", compositionId));
+//    }
     @Operation(
             summary = "AI 합성 요청",
             description = "AI 서버에 특정 영상 구간의 객체 탐지 및 합성을 요청합니다."
@@ -69,15 +92,11 @@ public class VideoCompositionController {
             @Parameter(hidden = true) Authentication authentication,
             @Parameter(description = "영상 ID", required = true)
             @PathVariable Long videoId,
-            @Parameter(description = "시작 시간 (HH:mm:ss, 기본값: 00:00:00)")
-            @RequestParam(defaultValue = "00:00:00") String startTime,
-            @Parameter(description = "구간 길이(초), 미입력 시 끝까지")
-            @RequestParam(required = false) Integer duration,
-            @Parameter(description = "객체 탐지 프롬프트", required = true)
-            @RequestParam String objectPrompt) {
+            @RequestBody @Valid AiCompositionRequest aiCompositionRequest) {
 
         String requesterEmail = authentication.getName();
-        Long compositionId = aiVideoService.requestAiComposition(requesterEmail, videoId, startTime, duration, objectPrompt);
+        Long compositionId = aiVideoService.requestAiComposition(requesterEmail, videoId, aiCompositionRequest.startTime()
+                , aiCompositionRequest.duration(), aiCompositionRequest.points());
         return ResponseEntity.accepted().body(Map.of("compositionId", compositionId));
     }
 

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/controller/VideoCompositionController.java
@@ -61,27 +61,6 @@ public class VideoCompositionController {
     // Uploader — request AI composition
     // -------------------------------------------------------------------------
 
-//    @Operation(
-//            summary = "AI 합성 요청",
-//            description = "AI 서버에 특정 영상 구간의 객체 탐지 및 합성을 요청합니다."
-//    )
-//    @PreAuthorize("hasAnyRole('UPLOADER', 'ADMIN')")
-//    @PostMapping("/{videoId}/ai-fetch")
-//    public ResponseEntity<Map<String, Long>> queueAiComposition(
-//            @Parameter(hidden = true) Authentication authentication,
-//            @Parameter(description = "영상 ID", required = true)
-//            @PathVariable Long videoId,
-//            @Parameter(description = "시작 시간 (HH:mm:ss, 기본값: 00:00:00)")
-//            @RequestParam(defaultValue = "00:00:00") String startTime,
-//            @Parameter(description = "구간 길이(초), 미입력 시 끝까지")
-//            @RequestParam(required = false) Integer duration,
-//            @Parameter(description = "객체 탐지 프롬프트", required = true)
-//            @RequestParam String objectPrompt) {
-//
-//        String requesterEmail = authentication.getName();
-//        Long compositionId = aiVideoService.requestAiComposition(requesterEmail, videoId, startTime, duration, objectPrompt);
-//        return ResponseEntity.accepted().body(Map.of("compositionId", compositionId));
-//    }
     @Operation(
             summary = "AI 합성 요청",
             description = "AI 서버에 특정 영상 구간의 객체 탐지 및 합성을 요청합니다."
@@ -96,7 +75,7 @@ public class VideoCompositionController {
 
         String requesterEmail = authentication.getName();
         Long compositionId = aiVideoService.requestAiComposition(requesterEmail, videoId, aiCompositionRequest.startTime()
-                , aiCompositionRequest.duration(), aiCompositionRequest.points());
+                , aiCompositionRequest.duration(), aiCompositionRequest.boundingBox());
         return ResponseEntity.accepted().body(Map.of("compositionId", compositionId));
     }
 

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/AiCompositionRequest.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/AiCompositionRequest.java
@@ -1,0 +1,14 @@
+package com.streamly.streamly.domain.videoComposition.entity;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record AiCompositionRequest(
+        @NotBlank String startTime,
+        Integer duration,
+        @NotEmpty List<ClickPoint> points
+) {
+
+}

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/AiCompositionRequest.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/AiCompositionRequest.java
@@ -1,14 +1,13 @@
 package com.streamly.streamly.domain.videoComposition.entity;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-
-import java.util.List;
+import jakarta.validation.constraints.NotNull;
 
 public record AiCompositionRequest(
         @NotBlank String startTime,
         Integer duration,
-        @NotEmpty List<ClickPoint> points
+        @NotNull @Valid BoundingBox boundingBox
 ) {
 
 }

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/AiCompositionRequest.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/AiCompositionRequest.java
@@ -3,10 +3,11 @@ package com.streamly.streamly.domain.videoComposition.entity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record AiCompositionRequest(
         @NotBlank String startTime,
-        Integer duration,
+        @NotNull @Positive Integer duration,
         @NotNull @Valid BoundingBox boundingBox
 ) {
 

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/BoundingBox.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/BoundingBox.java
@@ -1,0 +1,15 @@
+package com.streamly.streamly.domain.videoComposition.entity;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 객체 탐지용 바운딩 박스 — 프레임 크기에 무관한 정규화 좌표(0~1)로 표현한다.
+ * (x, y)는 좌상단 모서리, (width, height)는 정규화된 너비/높이.
+ */
+public record BoundingBox(
+        @NotNull Double x,
+        @NotNull Double y,
+        @NotNull Double width,
+        @NotNull Double height
+) {
+}

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/ClickPoint.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/ClickPoint.java
@@ -1,6 +1,0 @@
-package com.streamly.streamly.domain.videoComposition.entity;
-
-import jakarta.validation.constraints.NotNull;
-
-public record ClickPoint(@NotNull Double x, @NotNull Double y, @NotNull Integer label) {
-}

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/ClickPoint.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/ClickPoint.java
@@ -1,0 +1,6 @@
+package com.streamly.streamly.domain.videoComposition.entity;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ClickPoint(@NotNull Double x, @NotNull Double y, @NotNull Integer label) {
+}

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/VideoComposition.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/VideoComposition.java
@@ -34,8 +34,9 @@ public class VideoComposition {
     @Column(name = "task_id")
     private String taskId;
 
-    @Column(name = "object_prompt", nullable = false)
-    private String objectPrompt;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "click_points", columnDefinition = "json", nullable = false)
+    private String clickPoints;
 
     @Column(name = "start_time", nullable = false)
     private String startTime;

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/entity/VideoComposition.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/entity/VideoComposition.java
@@ -35,8 +35,8 @@ public class VideoComposition {
     private String taskId;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "click_points", columnDefinition = "json", nullable = false)
-    private String clickPoints;
+    @Column(name = "bounding_box", columnDefinition = "json", nullable = false)
+    private String boundingBox;
 
     @Column(name = "start_time", nullable = false)
     private String startTime;

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/service/VideoCompositionService.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/service/VideoCompositionService.java
@@ -89,18 +89,19 @@ public class VideoCompositionService {
 
     @Transactional
     public Long initialSave(VideoComposeMessage message) {
-        if (message.getVideoId() == null || message.getStartTime() == null || message.getDuration() == null) {
+        if (message.getVideoId() == null || message.getStartTime() == null
+                || message.getDuration() == null || message.getBoundingBox() == null) {
             throw new IllegalArgumentException("합성 요청 필수값이 누락되었습니다.");
         }
-        String clickPointsJson;
+        String boundingBoxJson;
         try{
-            clickPointsJson = objectMapper.writeValueAsString(message.getPoints());
+            boundingBoxJson = objectMapper.writeValueAsString(message.getBoundingBox());
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("클릭 포인트 직렬화에 실패했습니다.", e);
+            throw new IllegalArgumentException("바운딩 박스 직렬화에 실패했습니다.", e);
         }
         VideoComposition composition = VideoComposition.builder()
                 .videoId(message.getVideoId())
-                .clickPoints(clickPointsJson)
+                .boundingBox(boundingBoxJson)
                 .startTime(message.getStartTime())
                 .duration(message.getDuration())
                 .build();

--- a/src/main/java/com/streamly/streamly/domain/videoComposition/service/VideoCompositionService.java
+++ b/src/main/java/com/streamly/streamly/domain/videoComposition/service/VideoCompositionService.java
@@ -1,5 +1,6 @@
 package com.streamly.streamly.domain.videoComposition.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.streamly.streamly.domain.advertiser.repository.AdVideoRepository;
 import com.streamly.streamly.domain.user.entity.User;
@@ -88,13 +89,18 @@ public class VideoCompositionService {
 
     @Transactional
     public Long initialSave(VideoComposeMessage message) {
-        if (message.getVideoId() == null || message.getObjectPrompt() == null
-                || message.getStartTime() == null || message.getDuration() == null) {
+        if (message.getVideoId() == null || message.getStartTime() == null || message.getDuration() == null) {
             throw new IllegalArgumentException("합성 요청 필수값이 누락되었습니다.");
+        }
+        String clickPointsJson;
+        try{
+            clickPointsJson = objectMapper.writeValueAsString(message.getPoints());
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("클릭 포인트 직렬화에 실패했습니다.", e);
         }
         VideoComposition composition = VideoComposition.builder()
                 .videoId(message.getVideoId())
-                .objectPrompt(message.getObjectPrompt())
+                .clickPoints(clickPointsJson)
                 .startTime(message.getStartTime())
                 .duration(message.getDuration())
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #51 

## 📝 작업 내용

AI 합성 요청 시 객체 지정 방식을 텍스트 프롬프트(objectPrompt)에서 사용자가 영상 프레임에 드래그로 그린 바운딩 박스 좌표를 전달하는 방식으로 변경했습니다.

AiCompositionRequest 요청 DTO 신설: startTime, duration, boundingBox를 하나의 @RequestBody로 받도록 변경 (기존 @RequestParam 방식 제거)
BoundingBox record 추가: 프레임 해상도에 무관하도록 정규화 좌표(0~1) 로 표현 (x, y는 좌상단 모서리, width, height는 정규화된 너비/높이)
VideoComposeMessage(RabbitMQ로 AI 서버에 전달하는 메시지) 필드를 objectPrompt → boundingBox로 교체
AiVideoService.requestAiComposition() 시그니처를 boundingBox 파라미터를 받도록 수정
VideoComposition 엔티티: object_prompt 컬럼 제거, bounding_box(JSON, NOT NULL) 컬럼으로 대체 → VideoCompositionService.initialSave()에서 JSON 직렬화 후 저장
DB 마이그레이션 스크립트(db/alter_video_compositions_bounding_box.sql) 추가
bounding_box json 컬럼 추가 (기존 행은 '{}'로 채운 뒤 NOT NULL 설정)
구 컬럼 object_prompt 및 중간 실험 단계에서 쓰인 click_points 컬럼 제거
ddl-auto=update는 기존 데이터가 있는 테이블에 NOT NULL 컬럼을 자동 생성하지 못해 별도 마이그레이션 필요

⚠️ 테스트 시 주의: 스키마 변경으로 인해 기존 DB에는 alter_video_compositions_bounding_box.sql을 먼저 실행해야 합니다. 미실행 시 column bounding_box does not exist 로 INSERT가 실패합니다.

### ✨ 스크린샷

### 💬 리뷰 요구사항
